### PR TITLE
DOCUMENTATION: Update the 'type' options to include 'rateLimit' in site rules

### DIFF
--- a/docs/resources/site_rule.md
+++ b/docs/resources/site_rule.md
@@ -40,7 +40,7 @@ resource "sigsci_site_rule" "test" {
 
 ### Argument Reference
  - `site_short_names` - (Required) Sites with the rule available. Rules with a global corpScope will return '[]'.
- - `type`  Type of rule (request, signal, multival, templatedSignal).
+ - `type`  Type of rule (rateLimit, request, signal, multival, templatedSignal).
  - `enabled` - (Required) enabled or disabled
  - `group_operator` -   Conditions that must be matched when evaluating the request (all, any)
  - `signal`  -   The signal id of the signal being excluded or tagged. Only used for type=signal


### PR DESCRIPTION
`rateLimit` already works and is a valid option in the [codebase](https://github.com/signalsciences/terraform-provider-sigsci/blob/ca52359600535d027a8675b0def5896d2668cf99/provider/resource_site_rule.go#L20) but not in the documentation. 

Therefore, in order to make it clearer for consumers of this provider, it is a good idea to include the valid option in the documentation.