### PR TITLE
unify allowed values for condition field/type across code/docs

### DIFF
--- a/docs/resources/corp_rule.md
+++ b/docs/resources/corp_rule.md
@@ -40,9 +40,9 @@ resource "sigsci_corp_rule" "test" {
  - `reason`  -   Description of the rule
  - `expiration` -   (Required) Date the rule will automatically be disabled. If rule is always enabled, will return empty string (RFC3339 date time)
  - `conditions` -   Conditions on which the rule should trigger. May be recursively nest up to 3 times.
-   - `type` - (Required) (group, single)
-   - `group_operator` -  type: group - Conditions that must be matched when evaluating the request (all, any)
-   - `field` -  type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, queryParameter)
+   - `type` - (Required) (group, multival, single)
+   - `group_operator` -  type: group, multival - Conditions that must be matched when evaluating the request (all, any)
+   - `field` -  type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, signal, requestHeader, queryParameter, postParameter)
    - `operator` -  type: single - (equals, doesNotEqual, contains, doesNotContain, like, notLike, exists, doesNotExist, inList, notInList)
    - `value` -  type: single - See request fields (https://docs.signalsciences.net/using-signal-sciences/features/rules/#request-fields)
    - `conditions` -  Conditions on which this condition should trigger. Can recursively add this 3 deep.

--- a/docs/resources/site_rule.md
+++ b/docs/resources/site_rule.md
@@ -47,9 +47,9 @@ resource "sigsci_site_rule" "test" {
  - `reason`  -   Description of the rule
  - `expiration` - (Required) Date the rule will automatically be disabled. If rule is always enabled, will return empty string (RFC3339 date time)
  - `conditions` -   Conditions on which the rule should trigger. May be recursively nest up to 3 times.
-   - `type` - (Required) (group, single)
-   - `group_operator` -  type: group - Conditions that must be matched when evaluating the request (all, any)
-   - `field` -  type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, queryParameter)
+   - `type` - (Required) (group, multival, single)
+   - `group_operator` -  type: group, multival - Conditions that must be matched when evaluating the request (all, any)
+   - `field` -  type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, signal, requestHeader, queryParameter, postParameter)
    - `operator` -  type: single - (equals, doesNotEqual, contains, doesNotContain, like, notLike, exists, doesNotExist, inList, notInList)
    - `value` -  type: single - See request fields (https://docs.signalsciences.net/using-signal-sciences/features/rules/#request-fields)
    - `conditions` -  Conditions on which this condition should trigger. Can recursively add this 3 deep.

--- a/provider/lib.go
+++ b/provider/lib.go
@@ -481,8 +481,8 @@ var siteImporter = schema.ResourceImporter{
 }
 
 func validateConditionField(val interface{}, key string) ([]string, []error) {
-	if existsInString(val.(string), "scheme","method","path","useragent","domain","ip","responseCode","agentname","paramname","paramvalue","country","name","valueString","valueIp","signalType","signal", "requestHeader", "postParameter") {
+	if existsInString(val.(string), "scheme","method","path","useragent","domain","ip","responseCode","agentname","paramname","paramvalue","country","name","valueString","valueIp","signalType","signal", "requestHeader", "queryParameter", "postParameter") {
 		return nil, nil
 	}
-	return []string{fmt.Sprintf("received '%s' for conditions.field. This is not necessairly an error, but we only know about the following values. If this is a new value, please open a PR to get it added.\n(scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, signal, requestHeader, postParameter)", val.(string))}, nil
+	return []string{fmt.Sprintf("received '%s' for conditions.field. This is not necessairly an error, but we only know about the following values. If this is a new value, please open a PR to get it added.\n(scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, signal, requestHeader, queryParameter, postParameter)", val.(string))}, nil
 }

--- a/provider/resource_corp_rule.go
+++ b/provider/resource_corp_rule.go
@@ -77,12 +77,12 @@ func resourceCorpRule() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"type": {
 							Type:        schema.TypeString,
-							Description: "(group, single)",
+							Description: "(group, multival, single)",
 							Required:    true,
 						},
 						"field": {
 							Type:        schema.TypeString,
-							Description: "type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType)",
+							Description: "type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, signal, requestHeader, queryParameter, postParameter)",
 							Optional:    true,
 							ValidateFunc: validateConditionField,
 						},
@@ -93,7 +93,7 @@ func resourceCorpRule() *schema.Resource {
 						},
 						"group_operator": {
 							Type:        schema.TypeString,
-							Description: "type: group - Conditions that must be matched when evaluating the request (all, any)",
+							Description: "type: group, multival - Conditions that must be matched when evaluating the request (all, any)",
 							Optional:    true,
 							// ConflictsWith: []string{"conditions.0.operator", "conditions.0.value", "conditions.0.field", "conditions.1.operator", "conditions.1.value", "conditions.1.field"}, does # work here
 						},
@@ -111,12 +111,12 @@ func resourceCorpRule() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"type": {
 										Type:        schema.TypeString,
-										Description: "(group, single)",
+										Description: "(group, multival, single)",
 										Required:    true,
 									},
 									"field": {
 										Type:        schema.TypeString,
-										Description: "type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType)",
+										Description: "type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, signal, requestHeader, queryParameter, postParameter)",
 										Optional:    true,
 										ValidateFunc: validateConditionField,
 									},
@@ -127,7 +127,7 @@ func resourceCorpRule() *schema.Resource {
 									},
 									"group_operator": {
 										Type:        schema.TypeString,
-										Description: "type: group - Conditions that must be matched when evaluating the request (all, any)",
+										Description: "type: group, multival - Conditions that must be matched when evaluating the request (all, any)",
 										Optional:    true,
 									},
 									"value": {
@@ -144,12 +144,12 @@ func resourceCorpRule() *schema.Resource {
 											Schema: map[string]*schema.Schema{
 												"type": {
 													Type:        schema.TypeString,
-													Description: "(group, single)",
+													Description: "(group, multival, single)",
 													Required:    true,
 												},
 												"field": {
 													Type:        schema.TypeString,
-													Description: "type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType)",
+													Description: "type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, signal, requestHeader, queryParameter, postParameter)",
 													Optional:    true,
 													ValidateFunc: validateConditionField,
 												},
@@ -160,7 +160,7 @@ func resourceCorpRule() *schema.Resource {
 												},
 												"group_operator": {
 													Type:        schema.TypeString,
-													Description: "type: group - Conditions that must be matched when evaluating the request (all, any)",
+													Description: "type: group, multival - Conditions that must be matched when evaluating the request (all, any)",
 													Optional:    true,
 												},
 												"value": {

--- a/provider/resource_site_rule.go
+++ b/provider/resource_site_rule.go
@@ -75,12 +75,12 @@ func resourceSiteRule() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"type": {
 							Type:        schema.TypeString,
-							Description: "(group, single)",
+							Description: "(group, multival, single)",
 							Required:    true,
 						},
 						"field": {
 							Type:        schema.TypeString,
-							Description: "type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, signal)",
+							Description: "type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, signal, requestHeader, queryParameter, postParameter)",
 							Optional:    true,
 							ValidateFunc: validateConditionField,
 						},
@@ -91,7 +91,7 @@ func resourceSiteRule() *schema.Resource {
 						},
 						"group_operator": {
 							Type:        schema.TypeString,
-							Description: "type: group - Conditions that must be matched when evaluating the request (all, any)",
+							Description: "type: group, multival - Conditions that must be matched when evaluating the request (all, any)",
 							Optional:    true,
 						},
 						"value": {
@@ -108,12 +108,12 @@ func resourceSiteRule() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"type": {
 										Type:        schema.TypeString,
-										Description: "(group, single)",
+										Description: "(group, multival, single)",
 										Required:    true,
 									},
 									"field": {
 										Type:        schema.TypeString,
-										Description: "type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, signal)",
+										Description: "type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, signal, requestHeader, queryParameter, postParameter)",
 										Optional:    true,
 										ValidateFunc: validateConditionField,
 									},
@@ -124,7 +124,7 @@ func resourceSiteRule() *schema.Resource {
 									},
 									"group_operator": {
 										Type:        schema.TypeString,
-										Description: "type: group - Conditions that must be matched when evaluating the request (all, any)",
+										Description: "type: group, multival - Conditions that must be matched when evaluating the request (all, any)",
 										Optional:    true,
 									},
 									"value": {
@@ -141,12 +141,12 @@ func resourceSiteRule() *schema.Resource {
 											Schema: map[string]*schema.Schema{
 												"type": {
 													Type:        schema.TypeString,
-													Description: "(group, single)",
+													Description: "(group, multival, single)",
 													Required:    true,
 												},
 												"field": {
 													Type:        schema.TypeString,
-													Description: "type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, signal)",
+													Description: "type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, signal, requestHeader, queryParameter, postParameter)",
 													Optional:    true,
 													ValidateFunc: validateConditionField,
 												},
@@ -157,7 +157,7 @@ func resourceSiteRule() *schema.Resource {
 												},
 												"group_operator": {
 													Type:        schema.TypeString,
-													Description: "type: group - Conditions that must be matched when evaluating the request (all, any)",
+													Description: "type: group, multival - Conditions that must be matched when evaluating the request (all, any)",
 													Optional:    true,
 												},
 												"value": {


### PR DESCRIPTION
Add multival to "type" (currently group, single in most places)
Ensure requestHeader, queryParameter and postParameter are mentioned everywhere for "field"