### PR TITLE
[Issue-64] Mark interval as required field for site alerts

### DIFF
--- a/docs/resources/site_alert.md
+++ b/docs/resources/site_alert.md
@@ -18,7 +18,7 @@ resource "sigsci_site_alert" "test" {
  - `tag_name` - (Required) The name of the tag whose occurrences the alert is watching. Must match an existing tag
  - `long_name` -  A human readable description of the alert. Must be between 3 and 25 characters.
  - `interval` - (Required) The number of minutes of past traffic to examine. Must be 1, 10 or 60.
- - `threshold` - The number of occurrences of the tag in the interval needed to trigger the alert.
+ - `threshold` - (Required) The number of occurrences of the tag in the interval needed to trigger the alert.
  - `action` -  A flag that describes what happens when the alert is triggered. 'info' creates an incident in the dashboard. 'flagged' creates an incident and blocks traffic for 24 hours.
  - `skip_notifications` -  A boolean flag to send notifications
 

--- a/docs/resources/site_alert.md
+++ b/docs/resources/site_alert.md
@@ -17,7 +17,7 @@ resource "sigsci_site_alert" "test" {
  - `site_short_name` - (Required) Identifying name of the site
  - `tag_name` - (Required) The name of the tag whose occurrences the alert is watching. Must match an existing tag
  - `long_name` -  A human readable description of the alert. Must be between 3 and 25 characters.
- - `interval` - The number of minutes of past traffic to examine. Must be 1, 10 or 60.
+ - `interval` - (Required) The number of minutes of past traffic to examine. Must be 1, 10 or 60.
  - `threshold` - The number of occurrences of the tag in the interval needed to trigger the alert.
  - `action` -  A flag that describes what happens when the alert is triggered. 'info' creates an incident in the dashboard. 'flagged' creates an incident and blocks traffic for 24 hours.
  - `skip_notifications` -  A boolean flag to send notifications


### PR DESCRIPTION
[Issue-64](https://github.com/signalsciences/terraform-provider-sigsci/issues/64)

In the [documentation](https://registry.terraform.io/providers/signalsciences/sigsci/latest/docs/resources/site_alert), interval and threshold are not marked as required fields but while applying the change in terraform, you get the followig errors: 
* `Error: Interval must be 1, 10 or 60`. 
* `Error: Threshold must be between 1 and 10000`

This change marks them as a required field.