### PR TITLE
Redact access_key/secret_key secrets from stdout

### DIFF
--- a/provider/resource_site.go
+++ b/provider/resource_site.go
@@ -66,10 +66,12 @@ func resourceSite() *schema.Resource {
 						"secret_key": {
 							Type:     schema.TypeString,
 							Computed: true,
+							Sensitive: true,
 						},
 						"access_key": {
 							Type:     schema.TypeString,
 							Computed: true,
+							Sensitive: true,
 						},
 					},
 				},


### PR DESCRIPTION
A user does not want sensitive secret information to be stored in their logs.

Internal Slack conversation: https://fastly-support.slack.com/archives/C03KSJGM9CJ/p1659455064094449