### PR TITLE
Add Cloud WAF Instance response computed properties

### DIFF
--- a/provider/resource_corp_cloudwaf_instance.go
+++ b/provider/resource_corp_cloudwaf_instance.go
@@ -20,11 +20,6 @@ func resourceCorpCloudWAFInstance() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		Schema: map[string]*schema.Schema{
-			"cloudwaf_instance_id": {
-				Type:        schema.TypeString,
-				Description: "CloudWAF instance unique identifier.",
-				Computed:    true,
-			},
 			"name": {
 				Type:        schema.TypeString,
 				Description: "Friendly name to identify a CloudWAF instance.",
@@ -258,10 +253,6 @@ func resourceCorpCloudWAFInstanceRead(d *schema.ResourceData, m interface{}) err
 	}
 
 	d.SetId(d.Id())
-	err = d.Set("cloudwaf_instance_id", cwaf.ID)
-	if err != nil {
-		return err
-	}
 	err = d.Set("name", cwaf.Name)
 	if err != nil {
 		return err

--- a/provider/resource_corp_cloudwaf_instance_test.go
+++ b/provider/resource_corp_cloudwaf_instance_test.go
@@ -42,7 +42,6 @@ func TestAccResourceCorpCloudWAFInstanceCRUD(t *testing.T) {
 				}`, testSite),
 
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet(resourceName, "cloudwaf_instance_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", "Cloud WAF created by SigSci Terraform provider test"),
 					resource.TestCheckResourceAttr(resourceName, "description", "Test CWAF Created by SigSci Terraform provider"),
 					resource.TestCheckResourceAttr(resourceName, "region", "us-west-1"),

--- a/provider/resource_corp_cloudwaf_instance_test.go
+++ b/provider/resource_corp_cloudwaf_instance_test.go
@@ -42,6 +42,7 @@ func TestAccResourceCorpCloudWAFInstanceCRUD(t *testing.T) {
 				}`, testSite),
 
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "cloudwaf_instance_id"),
 					resource.TestCheckResourceAttr(resourceName, "name", "Cloud WAF created by SigSci Terraform provider test"),
 					resource.TestCheckResourceAttr(resourceName, "description", "Test CWAF Created by SigSci Terraform provider"),
 					resource.TestCheckResourceAttr(resourceName, "region", "us-west-1"),
@@ -60,6 +61,8 @@ func TestAccResourceCorpCloudWAFInstanceCRUD(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "workspace_configs.368698502.routes.3172309932.origin", "https://example.com"),
 					resource.TestCheckResourceAttr(resourceName, "workspace_configs.368698502.routes.3172309932.pass_host_header", "false"),
 					resource.TestCheckResourceAttr(resourceName, "workspace_configs.368698502.routes.3172309932.trust_proxy_headers", "true"),
+					resource.TestCheckResourceAttr(resourceName, "deployment.0.status", "done"),
+					resource.TestCheckResourceAttrSet(resourceName, "deployment.0.dns_entry"),
 				),
 			},
 			{


### PR DESCRIPTION
Enhancement to add Cloud WAF Instance read response computed properties for:

1. ~~`cloudwaf_instance_id` - This maps to the API response `id` property. The name has been modified for Terraform as `id` is not an allowed field name. The error is `id is a reserved field name for a resource`. See more here: https://github.com/russellcardullo/terraform-provider-pingdom/issues/11~~ removed as duplicate to `id` value.
2. `deployment` - This maps to the `deployment` API response property. While this is a JSON object in the API response, this is currently implemented as  `schema.TypeList` with `MaxItems` set to `1` instead of being a `schema.TypeMap` due to a limitation in the Terraform Provider Go SDK which requires `schema.TypeMap` values to be strings. Using a `TypeList` wil result in deterministic 0-based hash indexes, so a property can be retrieved as `deployment.0.dns_entry`. This limitation conflicts with implementing `deployment.egressIPs` which is an array of object. See more here: https://github.com/hashicorp/terraform-plugin-sdk/issues/62