### PR TITLE
add go build github workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+name: Go build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.19
+
+    - name: Build
+      run: go build ./...


### PR DESCRIPTION
A PR like [this one](https://github.com/signalsciences/terraform-provider-sigsci/pull/81) should fail because it uses an attribute (`BlockDurationSeconds`) which doesn't exist yet in the `go-sigsci` library. 

A call to `go build` would fail in that case:

```
➜  terraform-provider-sigsci git:(alert-blockduration) go build ./...
# github.com/signalsciences/terraform-provider-sigsci/provider
provider/resource_site_alert.go:78:3: unknown field 'BlockDurationSeconds' in struct literal of type sigsci.CustomAlertBody
provider/resource_site_alert.go:150:3: unknown field 'BlockDurationSeconds' in struct literal of type sigsci.CustomAlertBody
```