### PR TITLE
[BUG] Fixed resource schema for `requestlogging` in `sigsci_site_rule`

### DIFF
--- a/provider/resource_site_rule.go
+++ b/provider/resource_site_rule.go
@@ -50,7 +50,8 @@ func resourceSiteRule() *schema.Resource {
 			"requestlogging": {
 				Type:        schema.TypeString,
 				Description: "Indicates whether to store the logs for requests that match the rule's conditions (sampled) or not store them (none). This field is only available for request rules that have a block or allow action.",
-				Required:    false,
+				Optional:    true,
+				Default:     "sampled",
 			},
 			"actions": {
 				Type:        schema.TypeSet,


### PR DESCRIPTION
Hi, 

Fixed a bug in `sigsci_site_rule` of terraform-provider-sigsci v1.2.0 released yesterday, which caused errors such as `terarform plan`.

related issue: https://github.com/signalsciences/terraform-provider-sigsci/issues/89