### PR TITLE
sigsci_site_templated_rule: interval value of 0 fails validation

### DIFF
--- a/docs/resources/site_templated_rule.md
+++ b/docs/resources/site_templated_rule.md
@@ -50,7 +50,7 @@ resource "sigsci_site_templated_rule" "test_template_rule" {
   - `enabled` - (Required) A flag to toggle this alert.
   - `action` - (Required) A flag that describes what happens when the alert is triggered. 'info' creates an incident in the dashboard. 'flagged' creates an incident and blocks traffic for 24 hours.
   - `block_duration_seconds` - (Required) Duration to block for in seconds
-  - `interval` - The number of minutes of past traffic to examine. Must be 0, 1, 10 or 60.
+  - `interval` - The number of minutes of past traffic to examine. Must be 1, 10 or 60.
   - `threshold` - The number of occurrences of the tag in the interval needed to trigger the alert.
 
 ### Attributes Reference


### PR DESCRIPTION
Update `sigsci_site_templated_rule` resource documentation. Providing an [`interval`](https://registry.terraform.io/providers/signalsciences/sigsci/latest/docs/resources/site_templated_rule#interval) of `0` fails API validation.

```
$ curl 'https://dashboard.signalsciences.net/api/v0/corps/example/sites/example/configuredtemplates/AWS-SSRF' \
  --data-raw '{"alertAdds":[{"action":"info","enabled":true,"interval":0,"skipNotifications":false,"longName":"AWS-SSRF-1-in-1","threshold":1}],"alertDeletes":[],"alertUpdates":[],"detectionAdds":[{"name":"AWS-SSRF","enabled":true,"fields":[]}],"detectionDeletes":[],"detectionUpdates":[]}'

{"message":"Validation failed"}
```