### PR TITLE
return error when updating an integration fails

### DIFF
--- a/provider/resource_site_integration.go
+++ b/provider/resource_site_integration.go
@@ -111,7 +111,7 @@ func resourceSiteIntegrationUpdate(d *schema.ResourceData, m interface{}) error 
 	if err != nil {
 		log.Printf("[ERROR] %s. Could not update integration with ID %s in corp %s site %s", err.Error(), d.Id(), pm.Corp, site)
 		d.SetId("")
-		return nil
+		return err
 	}
 	return resourceSiteIntegrationRead(d, m)
 }


### PR DESCRIPTION
Related: https://github.com/signalsciences/terraform-provider-sigsci/issues/50

This surfaces the actual error when an update fails, so we don't need to run with `TF_LOG=1` to see it.