### PR TITLE
site alert interval, threshold, action required

### DIFF
--- a/docs/resources/site_alert.md
+++ b/docs/resources/site_alert.md
@@ -31,18 +31,18 @@ resource "sigsci_site_alert" "test" {
 
 ### Required
 
+- `interval` (Number) The number of minutes of past traffic to examine. Must be 1, 10 or 60.
 - `site_short_name` (String) Site short name
 - `tag_name` (String) The name of the tag whose occurrences the alert is watching. Must match an existing tag
+- `threshold` (Number) The number of occurrences of the tag in the interval needed to trigger the alert. Min 1, Max 10000
 
 ### Optional
 
 - `action` (String) A flag that describes what happens when the alert is triggered. 'info' creates an incident in the dashboard. 'flagged' creates an incident and blocks traffic for 24 hours. Must be info or flagged.
 - `block_duration_seconds` (Number) The number of seconds this alert is active.
 - `enabled` (Boolean) A flag to toggle this alert.
-- `interval` (Number) The number of minutes of past traffic to examine. Must be 1, 10 or 60.
 - `long_name` (String) description
 - `skip_notifications` (Boolean) A flag to skip notifications
-- `threshold` (Number) The number of occurrences of the tag in the interval needed to trigger the alert. Min 1, Max 10000
 
 ### Read-Only
 

--- a/docs/resources/site_alert.md
+++ b/docs/resources/site_alert.md
@@ -31,6 +31,7 @@ resource "sigsci_site_alert" "test" {
 
 ### Required
 
+- `action` (String) A flag that describes what happens when the alert is triggered. 'info' creates an incident in the dashboard. 'flagged' creates an incident and blocks traffic for 24 hours. Must be info or flagged.
 - `interval` (Number) The number of minutes of past traffic to examine. Must be 1, 10 or 60.
 - `site_short_name` (String) Site short name
 - `tag_name` (String) The name of the tag whose occurrences the alert is watching. Must match an existing tag
@@ -38,7 +39,6 @@ resource "sigsci_site_alert" "test" {
 
 ### Optional
 
-- `action` (String) A flag that describes what happens when the alert is triggered. 'info' creates an incident in the dashboard. 'flagged' creates an incident and blocks traffic for 24 hours. Must be info or flagged.
 - `block_duration_seconds` (Number) The number of seconds this alert is active.
 - `enabled` (Boolean) A flag to toggle this alert.
 - `long_name` (String) description

--- a/docs/resources/site_rule.md
+++ b/docs/resources/site_rule.md
@@ -58,6 +58,7 @@ resource "sigsci_site_rule" "test" {
 
 ### Required
 
+- `actions` (Block Set, Min: 1, Max: 2) Actions (see [below for nested schema](#nestedblock--actions))
 - `conditions` (Block Set, Min: 1, Max: 10) Conditions (see [below for nested schema](#nestedblock--conditions))
 - `enabled` (Boolean) enable the rule
 - `expiration` (String) Date the rule will automatically be disabled. If rule is always enabled, will return empty string
@@ -68,7 +69,6 @@ resource "sigsci_site_rule" "test" {
 
 ### Optional
 
-- `actions` (Block Set, Max: 2) Actions (see [below for nested schema](#nestedblock--actions))
 - `rate_limit` (Map of String) Rate Limit
 - `requestlogging` (String) Indicates whether to store the logs for requests that match the rule's conditions (sampled) or not store them (none). This field is only available for request rules that have a block or allow action.
 - `signal` (String) The signal id of the signal being excluded
@@ -76,6 +76,19 @@ resource "sigsci_site_rule" "test" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--actions"></a>
+### Nested Schema for `actions`
+
+Required:
+
+- `type` (String) (block, allow, excludeSignal, addSignal) (rateLimit rule valid values: logRequest, blockSignal)
+
+Optional:
+
+- `response_code` (Number) HTTP code agent for agent to respond with. range: 400-499, defaults to '406' if not provided
+- `signal` (String) signal id to tag
+
 
 <a id="nestedblock--conditions"></a>
 ### Nested Schema for `conditions`
@@ -120,21 +133,6 @@ Optional:
 - `group_operator` (String) type: group, multival - Conditions that must be matched when evaluating the request (all, any)
 - `operator` (String) type: single - (equals, doesNotEqual, contains, doesNotContain, like, notLike, exists, doesNotExist, inList, notInList)
 - `value` (String) type: single - See request fields (https://docs.signalsciences.net/using-signal-sciences/features/rules/#request-fields)
-
-
-
-
-<a id="nestedblock--actions"></a>
-### Nested Schema for `actions`
-
-Required:
-
-- `type` (String) (block, allow, excludeSignal, addSignal) (rateLimit rule valid values: logRequest, blockSignal)
-
-Optional:
-
-- `response_code` (Number) HTTP code agent for agent to respond with. range: 400-499, defaults to '406' if not provided
-- `signal` (String) signal id to tag
 
 ### Templated Signals
 We have curated a list of templates for common rules, the full list of available signals is available below.

--- a/provider/resource_site_alert.go
+++ b/provider/resource_site_alert.go
@@ -47,7 +47,7 @@ func resourceSiteAlert() *schema.Resource {
 			"action": {
 				Type:        schema.TypeString,
 				Description: "A flag that describes what happens when the alert is triggered. 'info' creates an incident in the dashboard. 'flagged' creates an incident and blocks traffic for 24 hours. Must be info or flagged.",
-				Optional:    true,
+				Required:    true,
 			},
 			"skip_notifications": {
 				Type:        schema.TypeBool,

--- a/provider/resource_site_alert.go
+++ b/provider/resource_site_alert.go
@@ -32,12 +32,12 @@ func resourceSiteAlert() *schema.Resource {
 			"interval": {
 				Type:        schema.TypeInt,
 				Description: "The number of minutes of past traffic to examine. Must be 1, 10 or 60.",
-				Optional:    true,
+				Required:    true,
 			},
 			"threshold": {
 				Type:        schema.TypeInt,
 				Description: "The number of occurrences of the tag in the interval needed to trigger the alert. Min 1, Max 10000",
-				Optional:    true,
+				Required:    true,
 			},
 			"enabled": {
 				Type:        schema.TypeBool,


### PR DESCRIPTION
When interval, threshold, or action are not set on site alert we get the following errors:

```
│ Error: Interval must be 1, 10 or 60
│ 
│   with sigsci_site_alert.test,
│   on main.tf line 23, in resource "sigsci_site_alert" "test":
│   23: resource "sigsci_site_alert" "test" {
```

```
│ Error: Threshold must be between 1 and 10000
│ 
│   with sigsci_site_alert.test,
│   on main.tf line 23, in resource "sigsci_site_alert" "test":
│   23: resource "sigsci_site_alert" "test" {
```

```
│ Error: Action must be 'flagged' or 'info'
│ 
│   with sigsci_site_alert.test,
│   on main.tf line 23, in resource "sigsci_site_alert" "test":
│   23: resource "sigsci_site_alert" "test" {
```

- set interval and threshold as required on site alert
- generate docs

Related: https://github.com/signalsciences/terraform-provider-sigsci/issues/64
