### PR TITLE
Set sensitive value at atttribute level to fix terraform destroy exposing sensitive values

### DIFF
--- a/provider/resource_site.go
+++ b/provider/resource_site.go
@@ -57,6 +57,7 @@ func resourceSite() *schema.Resource {
 				Type:        schema.TypeMap,
 				Description: "The sites primary Agent key",
 				Computed:    true,
+				Sensitive: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
@@ -66,12 +67,10 @@ func resourceSite() *schema.Resource {
 						"secret_key": {
 							Type:      schema.TypeString,
 							Computed:  true,
-							Sensitive: true,
 						},
 						"access_key": {
 							Type:      schema.TypeString,
 							Computed:  true,
-							Sensitive: true,
 						},
 					},
 				},


### PR DESCRIPTION
Terraform Destroy currently reveals sensitive values as a result of the issue described with nested element in:
https://github.com/hashicorp/terraform-plugin-sdk/issues/736

Output:

```
❯ terraform destroy
sigsci_site.terraform_site: Refreshing state... [id=terraform_site]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # sigsci_site.terraform_site will be destroyed
  - resource "sigsci_site" "terraform_site" {
      - agent_level            = "block" -> null
      - block_duration_seconds = 86400 -> null
      - block_http_code        = 406 -> null
      - display_name           = "jeremys terraform site" -> null
      - id                     = "terraform_site" -> null
      - primary_agent_key      = {
          - "access_key" = "567707e6-477e-4303-87ae-a902348093"
          - "name"       = "terraform_site"
          - "secret_key" = "8mvsgjrL_-oaIKN3tgOP2abgM_XXXXX"
        } -> null
      - short_name             = "terraform_site" -> null
    }
```

A good explanation of the issue can be found at:
https://github.com/hashicorp/terraform-provider-helm/issues/793#issuecomment-1061004986

> It seems that what happened here is that the provider or remote API internally copy values from the values argument into a provider-populated attribute metadata, which has its own attribute values. Although Terraform can see that values is sensitive, there's nothing here to tell Terraform that metadata.values is derived from values and therefore Terraform can't trace the sensitivity through the provider's "black box" and automatically understand that metadata.values ought to be sensitive too.

This PR performs changes from what I can see occurring as workarounds in the linked issues.

Resulting in the output

```
❯ terraform destroy
sigsci_site.terraform_site: Refreshing state... [id=terraform_sensitive]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # sigsci_site.terraform_site will be destroyed
  - resource "sigsci_site" "terraform_site" {
      - agent_level            = "block" -> null
      - block_duration_seconds = 86400 -> null
      - block_http_code        = 406 -> null
      - display_name           = "jeremys terraform meep" -> null
      - id                     = "terraform_sensitive" -> null
      - primary_agent_key      = (sensitive value)
      - short_name             = "terraform_sensitive" -> null
    }

Plan: 0 to add, 0 to change, 1 to destroy.
```

We do suffer visibility of the `name` element (which just reflects resource), so implications seem quite minimal around the actual issue. 

Cheers!

