### PR TITLE
Add validate option to allow bypassing of API credential check

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -48,6 +48,7 @@ provider "sigsci" {
 - `auth_token` (String, Sensitive) The token used for authentication specify either the password or the token
 - `fastly_key` (String, Sensitive) The Fastly API key used for deploying Signal Sciences as a Fastly edge security service. For edge deployment service       calls, the Fastly key must have write access to the given service.
 - `password` (String, Sensitive) The password used to for authentication specify either the password or the token
+* `validate` (Bool) Enable validation of API credentials during provider initialization. Default is true
 
 # Resources
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ provider "sigsci" {
 - `auth_token` (String, Sensitive) The token used for authentication specify either the password or the token
 - `fastly_key` (String, Sensitive) The Fastly API key used for deploying Signal Sciences as a Fastly edge security service. For edge deployment service       calls, the Fastly key must have write access to the given service.
 - `password` (String, Sensitive) The password used to for authentication specify either the password or the token
-* `validate` (Bool) Enable validation of API credentials during provider initialization. Default is true
+- `validate` (Bool) Enable validation of API credentials during provider initialization. Default is true
 
 # Resources
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -51,6 +51,12 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("SIGSCI_URL", nil),
 				Description: "URL override for testing",
 			},
+			"validate": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Enable validation of API credentials during provider initialization. Default is true.",
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"sigsci_site":                resourceSite(),
@@ -97,11 +103,16 @@ func providerConfigure() schema.ConfigureFunc {
 			Corp:   d.Get("corp").(string),
 			Client: client.(sigsci.Client),
 		}
-		// Test before continuing
-		_, err = metadata.Client.GetCorp(metadata.Corp)
-		if err != nil {
-			return nil, err
+
+		validate := d.Get("validate").(bool)
+		if validate {
+			// Test before continuing
+			_, err = metadata.Client.GetCorp(metadata.Corp)
+			if err != nil {
+				return nil, err
+			}
 		}
+
 		return metadata, nil
 	}
 }

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -42,6 +42,8 @@ make build
 - `auth_token` (String, Sensitive) The token used for authentication specify either the password or the token
 - `fastly_key` (String, Sensitive) The Fastly API key used for deploying Signal Sciences as a Fastly edge security service. For edge deployment service       calls, the Fastly key must have write access to the given service.
 - `password` (String, Sensitive) The password used to for authentication specify either the password or the token
+- `validate` (Bool) Enable validation of API credentials during provider initialization. Default is true
+
 
 # Resources
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -44,7 +44,6 @@ make build
 - `password` (String, Sensitive) The password used to for authentication specify either the password or the token
 - `validate` (Bool) Enable validation of API credentials during provider initialization. Default is true
 
-
 # Resources
 
 For examples of how to use each resource, see [docs/resources](./resources).


### PR DESCRIPTION
This adds a `validate` provider option that can be set to `false` when you need to skip validation of API credentials.

Fixes #71 