### PR TITLE
MINOR: examples: expand rate limit rule examples

### DIFF
--- a/examples/resources/sigsci_site_rule/resource.tf
+++ b/examples/resources/sigsci_site_rule/resource.tf
@@ -40,20 +40,20 @@ resource "sigsci_site_rule" "test-request-rule" {
   }
 }
 
-resource "sigsci_site_rule" "test-ratelimit-rule" {
+resource "sigsci_site_rule" "test-ratelimit-rule-conditions" {
   site_short_name = sigsci_site.my-site.short_name
   type            = "rateLimit"
   group_operator  = "all"
   enabled         = true
-  reason          = "Example rate limit rule"
-  signal          = "site.signal_id"
+  reason          = "Example rate limit rule that rate limits clients who match the rule conditions after exceeding threshold"
+  signal          = "site.count-ratelimit-rule1"
   expiration      = ""
 
   conditions {
     type     = "single"
-    field    = "ip"
+    field    = "path"
     operator = "equals"
-    value    = "1.2.3.5"
+    value    = "/login"
   }
 
   rate_limit = {
@@ -64,10 +64,65 @@ resource "sigsci_site_rule" "test-ratelimit-rule" {
 
   actions {
     type   = "logRequest"
-    signal = "site.signal_id"
+    signal = "site.count-ratelimit-rule1"
   }
 }
 
+resource "sigsci_site_rule" "test-ratelimit-other-signal" {
+  site_short_name = sigsci_site.my-site.short_name
+  type            = "rateLimit"
+  group_operator  = "all"
+  enabled         = true
+  reason          = "Example rate limit rule that rate limits clients who match a different signal after exceeding threshold"
+  signal          = "site.count-ratelimit-rule2"
+  expiration      = ""
+
+  conditions {
+    type     = "single"
+    field    = "path"
+    operator = "equals"
+    value    = "/reset_password"
+  }
+
+  rate_limit = {
+    threshold = 6
+    interval  = 10
+    duration  = 300
+  }
+
+  actions {
+    type   = "logRequest"
+    signal = "site.action-on-other-signal"
+  }
+}
+
+resource "sigsci_site_rule" "test-ratelimit-all-requests" {
+  site_short_name = sigsci_site.my-site.short_name
+  type            = "rateLimit"
+  group_operator  = "all"
+  enabled         = true
+  reason          = "Example rule that rate limits all requests from clients after exceeding threshold"
+  signal          = "site.count-ratelimit-rule3"
+  expiration      = ""
+
+  conditions {
+    type     = "single"
+    field    = "path"
+    operator = "equals"
+    value    = "/signup"
+  }
+
+  rate_limit = {
+    threshold = 6
+    interval  = 10
+    duration  = 300
+  }
+
+  actions {
+    type   = "logRequest"
+    signal = "ALL-REQUESTS"
+  }
+}
 
 resource "sigsci_site_rule" "test-signal-exclusion" {
   site_short_name = sigsci_site.my-site.short_name


### PR DESCRIPTION
We recently released an update to the rate limit rules user experience. While this change did not impact the API it did introduce a new signal `ALL-REQUESTS` that can be used when configuring rate limit rules. It has also been requested that we expand the terraform examples to show how different configurations that are done through the UI could be done within terraform.

This commit adds all 3 examples that could be configured from within the UI.

The example does not include the corresponding signal creation as the existing rule also did not include that.