### PR TITLE
remove t.Parallel() in TestResourceCorpRule_SortedSiteNames

### DIFF
--- a/provider/resource_corp_rule_test.go
+++ b/provider/resource_corp_rule_test.go
@@ -82,7 +82,6 @@ func TestResourceCorpRule_basic(t *testing.T) {
 
 // The api appears to sort site_short_names
 func TestResourceCorpRule_SortedSiteNames(t *testing.T) {
-	t.Parallel()
 	resourceName := "sigsci_corp_rule.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },


### PR DESCRIPTION
This test frequently fails because one of the sites it tries to create already exists from a previous test. Removing `t.Parallel()` seems to fix this.