### PR TITLE
change: added ValidateFunc for `sigsci_corp_integration`

### DIFF
--- a/provider/resource_corp_integration.go
+++ b/provider/resource_corp_integration.go
@@ -27,7 +27,7 @@ func resourceCorpIntegration() *schema.Resource {
 					if existsInString(val.(string), "mailingList", "slack", "microsoftTeams") {
 						return nil, nil
 					}
-					return nil, []error{fmt.Errorf("received type '%s' is invalid. should be 'mailingList', 'slack, or 'microsoftTeams'", val.(string))}
+					return nil, []error{fmt.Errorf("received type '%s' is invalid. should be 'mailingList', 'slack', or 'microsoftTeams'", val.(string))}
 				},
 			},
 			"url": {

--- a/provider/resource_corp_integration.go
+++ b/provider/resource_corp_integration.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -22,6 +23,12 @@ func resourceCorpIntegration() *schema.Resource {
 				Description: "One of (mailingList, slack, microsoftTeams)",
 				Required:    true,
 				ForceNew:    true,
+				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+					if existsInString(val.(string), "mailingList", "slack", "microsoftTeams") {
+						return nil, nil
+					}
+					return nil, []error{fmt.Errorf("received type '%s' is invalid. should be 'mailingList', 'slack, or 'microsoftTeams'", val.(string))}
+				},
 			},
 			"url": {
 				Type:        schema.TypeString,

--- a/provider/resource_corp_integration.go
+++ b/provider/resource_corp_integration.go
@@ -25,7 +25,7 @@ func resourceCorpIntegration() *schema.Resource {
 				ForceNew:    true,
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 					if !existsInString(val.(string), "mailingList", "slack", "microsoftTeams") {
-						return nil, []error{fmt.Errorf("received type %q is invalid. should be "mailingList", "slack", or "microsoftTeams"`, val.(string))}
+						return nil, []error{fmt.Errorf(`"received type %q is invalid. should be "mailingList", "slack", or "microsoftTeams"`, val.(string))}
 					}
 					return nil, nil
 				},

--- a/provider/resource_corp_integration.go
+++ b/provider/resource_corp_integration.go
@@ -24,10 +24,10 @@ func resourceCorpIntegration() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-					if existsInString(val.(string), "mailingList", "slack", "microsoftTeams") {
-						return nil, nil
+					if !existsInString(val.(string), "mailingList", "slack", "microsoftTeams") {
+						return nil, []error{fmt.Errorf("received type %q is invalid. should be "mailingList", "slack", or "microsoftTeams"`, val.(string))}
 					}
-					return nil, []error{fmt.Errorf("received type '%s' is invalid. should be 'mailingList', 'slack', or 'microsoftTeams'", val.(string))}
+					return nil, nil
 				},
 			},
 			"url": {


### PR DESCRIPTION
Hi, I added a validateFunc to `sigsci_corp_integration` resource.

- type
	- "mailingList", "slack" or "microsoftTeams"

```console
$ terraform validate
│ Error: received type 'Slack' is invalid. should be 'mailingList', 'slack', or 'microsoftTeams'
│
│   with module.corp.sigsci_corp_integration.name,
│   on corp/integration.tf line 1, in resource "sigsci_corp_integration" "name":
│    1: resource "sigsci_corp_integration" "name" {
```