### PR TITLE
Added ValidateFunc for `sigsci_corp_list`

### DIFF
--- a/provider/lib.go
+++ b/provider/lib.go
@@ -353,10 +353,7 @@ func existsInRange(needle int, min, max int) bool {
 func validStringLength(needle string, min, max int) bool {
 	length := len(needle)
 
-	if length >= min && length <= max {
-		return true
-	}
-	return false
+	return length >= min && length <= max
 }
 
 func expandRuleConditions(conditionsResource *schema.Set) []sigsci.Condition {

--- a/provider/lib.go
+++ b/provider/lib.go
@@ -350,6 +350,15 @@ func existsInRange(needle int, min, max int) bool {
 	return false
 }
 
+func validStringLength(needle string, min, max int) bool {
+	length := len(needle)
+
+	if length >= min && length <= max {
+		return true
+	}
+	return false
+}
+
 func expandRuleConditions(conditionsResource *schema.Set) []sigsci.Condition {
 	var conditions []sigsci.Condition
 	for _, genericElement := range conditionsResource.List() {

--- a/provider/resource_corp_integration.go
+++ b/provider/resource_corp_integration.go
@@ -25,7 +25,7 @@ func resourceCorpIntegration() *schema.Resource {
 				ForceNew:    true,
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 					if !existsInString(val.(string), "mailingList", "slack", "microsoftTeams") {
-						return nil, []error{fmt.Errorf(`"received type %q is invalid. should be "mailingList", "slack", or "microsoftTeams"`, val.(string))}
+						return nil, []error{fmt.Errorf(`received type %q is invalid. should be "mailingList", "slack", or "microsoftTeams"`, val.(string))}
 					}
 					return nil, nil
 				},

--- a/provider/resource_corp_list.go
+++ b/provider/resource_corp_list.go
@@ -47,7 +47,7 @@ func resourceCorpList() *schema.Resource {
 				Optional:    true,
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 					if !validStringLength(val.(string), 0, 140) {
-						return nil, []error{fmt.Errorf(`received name %q is invalid. should be max len 140`, val.(string))}
+						return nil, []error{fmt.Errorf(`received description %q is invalid. should be max len 140`, val.(string))}
 					}
 					return nil, nil
 				},

--- a/provider/resource_corp_list.go
+++ b/provider/resource_corp_list.go
@@ -21,16 +21,34 @@ func resourceCorpList() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "Descriptive list name",
 				Required:    true,
+				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+					if !validateStringLength(val.(string), 3, 32) {
+						return nil, []error{fmt.Errorf(`received name %q is invalid. should be min len 3, max len 32`, val.(string))}
+					}
+					return nil, nil
+				},
 			},
 			"type": {
 				Type:        schema.TypeString,
 				Description: "List types (string, ip, country, wildcard, signal)",
 				Required:    true,
+				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+					if !existsInString(val.(string), "string", "ip", "country", "wildcard", "signal") {
+						return nil, []error{fmt.Errorf(`received type %q is invalid. should be "string", "ip", "country", "wildcard" or "signal"`, val.(string))}
+					}
+					return nil, nil
+				},
 			},
 			"description": {
 				Type:        schema.TypeString,
 				Description: "Optional list description",
 				Optional:    true,
+				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+					if !validateStringLength(val.(string), 0, 140) {
+						return nil, []error{fmt.Errorf(`received name %q is invalid. should be max len 140`, val.(string))}
+					}
+					return nil, nil
+				},
 			},
 			"entries": {
 				Type:        schema.TypeSet,


### PR DESCRIPTION
Hi, 

Added some ValidateFunc for `sigsci_corp_list`. 

- `name`
- `type`
- `description`

Also, added new function “validStringLength” in `lib.go`. It’s validate of string length. It's useful when you need to validate the string length.

## Why only validate length?
Since the WebUI displays validation rules when an invalid value is entered, I considered creating a function like "validRegex" that could validate these using regular expressions.
(For example: https://github.com/hashicorp/terraform-provider-aws/blob/3db3102b34357187208b87b6825b6dcfd65e4bbb/.ci/providerlint/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation/strings.go#L90-L106)
![image](https://user-images.githubusercontent.com/29038315/229345643-b0a06ff0-27a1-4f31-b40c-11c0a0a08e25.png)

However, since the official documentation does not mention validation using regular expressions, I limited ourselves to length validation.
https://docs.fastly.com/signalsciences/api/#_corps__corpName__lists_post
![image](https://user-images.githubusercontent.com/29038315/229345225-0547fd14-023d-405c-a35d-5ce3ad2bb943.png)
