### PR TITLE
MEDIUM: site: allow updating default WAF block code

### DIFF
--- a/docs/resources/site.md
+++ b/docs/resources/site.md
@@ -35,10 +35,11 @@ resource "sigsci_site" "my-site" {
 - `agent_anon_mode` (String) Agent IP anonymization mode - "" (empty string) or 'EU'
 - `agent_level` (String) Agent action level - 'block', 'log' or 'off'
 - `block_duration_seconds` (Number) Duration to block an IP in seconds
+- `block_http_code` (Number) HTTP response code to send when traffic is being blocked
+- `block_redirect_url` (String) URL to redirect to when blocking with a '301' or '302' HTTP status code
 
 ### Read-Only
 
-- `block_http_code` (Number) HTTP response code to send when traffic is being blocked
 - `id` (String) The ID of this resource.
 - `primary_agent_key` (Map of String, Sensitive) The sites primary Agent key
 

--- a/docs/resources/site_rule.md
+++ b/docs/resources/site_rule.md
@@ -243,7 +243,8 @@ Required:
 
 Optional:
 
-- `response_code` (Number) HTTP code agent for agent to respond with. range: 400-499, defaults to '406' if not provided
+- `redirect_url` (String) URL to redirect to when blocking response code is set to 301 or 302
+- `response_code` (Number) HTTP code agent for agent to respond with. range: 301,302, or 400-599, defaults to '406' if not provided
 - `signal` (String) signal id to tag
 
 ### Templated Signals

--- a/docs/resources/site_rule.md
+++ b/docs/resources/site_rule.md
@@ -244,7 +244,7 @@ Required:
 Optional:
 
 - `redirect_url` (String) URL to redirect to when blocking response code is set to 301 or 302
-- `response_code` (Number) HTTP code agent for agent to respond with. range: 301,302, or 400-599, defaults to '406' if not provided
+- `response_code` (Number) HTTP code agent for agent to respond with. range: 301, 302, or 400-599, defaults to '406' if not provided
 - `signal` (String) signal id to tag
 
 ### Templated Signals

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/hashicorp/terraform-plugin-docs v0.14.1
 	github.com/hashicorp/terraform-plugin-sdk v1.14.0
-	github.com/signalsciences/go-sigsci v0.1.14
+	github.com/signalsciences/go-sigsci v0.1.15
 	golang.org/x/lint v0.0.0-20190409202823-959b441ac422
 	honnef.co/go/tools v0.4.2
 )
@@ -90,4 +90,5 @@ require (
 	google.golang.org/grpc v1.27.1 // indirect
 )
 
+//replace github.com/signalsciences/go-sigsci => /Users/dcorbett/src/go-sigsci
 //replace github.com/signalsciences/go-sigsci v0.1.6 => ../go-sigsci

--- a/go.sum
+++ b/go.sum
@@ -261,6 +261,8 @@ github.com/signalsciences/go-sigsci v0.1.13 h1:S8YVQ7ei0hybgWqGj0krle6GkA7l8k23V
 github.com/signalsciences/go-sigsci v0.1.13/go.mod h1:CXwoXk81ZwFdne6o8cnAYwxvke5kcLg7zE6Bl/e1KUo=
 github.com/signalsciences/go-sigsci v0.1.14 h1:a2ucWDWDjXn93NXrVBcd7zyOMjxUcPEznTpCg0CLB+g=
 github.com/signalsciences/go-sigsci v0.1.14/go.mod h1:CXwoXk81ZwFdne6o8cnAYwxvke5kcLg7zE6Bl/e1KUo=
+github.com/signalsciences/go-sigsci v0.1.15 h1:Z1Wkli5NtN8OsvBBWBgXRS0LpAsmVrl1dgCPqFrKglo=
+github.com/signalsciences/go-sigsci v0.1.15/go.mod h1:CXwoXk81ZwFdne6o8cnAYwxvke5kcLg7zE6Bl/e1KUo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=

--- a/provider/lib.go
+++ b/provider/lib.go
@@ -538,12 +538,12 @@ func validateConditionField(val interface{}, key string) ([]string, []error) {
 }
 
 func validateActionResponseCode(val interface{}, key string) ([]string, []error) {
-	// response code needs to be within 400-599
+	// response code needs to be 301, 302, or 400-599
 	code := val.(int)
 	if (code >= 301 && code <= 302) || (code >= 400 && code <= 599) {
 		return nil, nil
 	}
-	rangeError := fmt.Errorf("received action responseCode '%d'. should be in 400-599 range", code)
+	rangeError := fmt.Errorf("received action responseCode '%d'. should be in 301, 302, or 400-599", code)
 	return nil, []error{rangeError}
 }
 

--- a/provider/resource_site.go
+++ b/provider/resource_site.go
@@ -48,10 +48,15 @@ func resourceSite() *schema.Resource {
 				Optional:    true,
 				Default:     86400,
 			},
-			"block_http_code": { // CANNOT UPDATE THIS FIELD,
+			"block_http_code": {
 				Type:        schema.TypeInt,
 				Description: "HTTP response code to send when traffic is being blocked",
-				Computed:    true,
+				Optional:    true,
+			},
+			"block_redirect_url": {
+				Type:        schema.TypeString,
+				Description: "URL to redirect to when blocking with a '301' or '302' HTTP status code",
+				Optional:    true,
 			},
 			"primary_agent_key": {
 				Type:        schema.TypeMap,
@@ -89,6 +94,7 @@ func createSite(d *schema.ResourceData, m interface{}) error {
 		AgentAnonMode:        d.Get("agent_anon_mode").(string),
 		BlockHTTPCode:        d.Get("block_http_code").(int),
 		BlockDurationSeconds: d.Get("block_duration_seconds").(int),
+		BlockRedirectURL:     d.Get("block_redirect_url").(string),
 	})
 
 	if err != nil {
@@ -130,6 +136,10 @@ func readSite(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
+	err = d.Set("block_redirect_url", site.BlockRedirectURL)
+	if err != nil {
+		return err
+	}
 	err = d.Set("agent_anon_mode", site.AgentAnonMode)
 	if err != nil {
 		return err
@@ -165,6 +175,7 @@ func updateSite(d *schema.ResourceData, m interface{}) error {
 		AgentLevel:           d.Get("agent_level").(string),
 		BlockDurationSeconds: d.Get("block_duration_seconds").(int),
 		BlockHTTPCode:        d.Get("block_http_code").(int),
+		BlockRedirectURL:     d.Get("block_redirect_url").(string),
 		AgentAnonMode:        d.Get("agent_anon_mode").(string),
 	})
 	if err != nil {

--- a/provider/resource_site_rule.go
+++ b/provider/resource_site_rule.go
@@ -72,7 +72,7 @@ func resourceSiteRule() *schema.Resource {
 						},
 						"response_code": {
 							Type:         schema.TypeInt,
-							Description:  "HTTP code agent for agent to respond with. range: 301,302, or 400-599, defaults to '406' if not provided",
+							Description:  "HTTP code agent for agent to respond with. range: 301, 302, or 400-599, defaults to '406' if not provided",
 							Optional:     true,
 							ValidateFunc: validateActionResponseCode,
 							Default:      http.StatusNotAcceptable,

--- a/provider/resource_site_rule.go
+++ b/provider/resource_site_rule.go
@@ -72,10 +72,16 @@ func resourceSiteRule() *schema.Resource {
 						},
 						"response_code": {
 							Type:         schema.TypeInt,
-							Description:  "HTTP code agent for agent to respond with. range: 400-499, defaults to '406' if not provided",
+							Description:  "HTTP code agent for agent to respond with. range: 301,302, or 400-599, defaults to '406' if not provided",
 							Optional:     true,
 							ValidateFunc: validateActionResponseCode,
 							Default:      http.StatusNotAcceptable,
+						},
+						"redirect_url": {
+							Type:         schema.TypeString,
+							Description:  "URL to redirect to when blocking response code is set to 301 or 302",
+							Optional:     true,
+							ValidateFunc: validateActionRedirectURL,
 						},
 					},
 				},


### PR DESCRIPTION
This commit allows updating the default WAF blocking code. It supports blocking using 301 or 302 with a custom URL as well as 400-599. It also extends support for the existing site rule blocking codes to allow for the same response codes.

This commit requires the merge of signalsciences/go-sigsci#53