### PR TITLE
BUG/MINOR: site: set default block_http_code

### DIFF
--- a/provider/resource_site.go
+++ b/provider/resource_site.go
@@ -52,6 +52,7 @@ func resourceSite() *schema.Resource {
 				Type:        schema.TypeInt,
 				Description: "HTTP response code to send when traffic is being blocked",
 				Optional:    true,
+				Default:     406,
 			},
 			"block_redirect_url": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
It was pointed out in #161 that since the release of version 1.2.21 changes to apply continuously appear even when none are made if `block_http_code` was not specified. @sjparkinson rightfully pointed out the culprit was 2f7a101 (MEDIUM: site: allow updating default WAF block code)

Specifically, what was happening is that the API always responds with `blockHTTPCode` set even when it's using the default "406". However, from the terraform perspective this value was set to "null" and so it assumed that the 406 needed to be switched to "null". This commit updates the site resource file and properly sets "406" as the default. This fixes the conflict that was happening.