### PR TITLE
update site_rule doc with missing operator options

### DIFF
--- a/docs/resources/site_rule.md
+++ b/docs/resources/site_rule.md
@@ -199,7 +199,7 @@ Optional:
 - `conditions` (Block Set, Max: 10) Conditions (see [below for nested schema](#nestedblock--conditions--conditions))
 - `field` (String) type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, signal, requestHeader, queryParameter, postParameter)
 - `group_operator` (String) type: group, multival - Conditions that must be matched when evaluating the request (all, any)
-- `operator` (String) type: single - (equals, doesNotEqual, contains, doesNotContain, like, notLike, exists, doesNotExist, inList, notInList)
+- `operator` (String) type: single - (equals, doesNotEqual, contains, doesNotContain, like, notLike, exists, doesNotExist, matches, doesNotMatch, inList, notInList)
 - `value` (String) type: single - See request fields (https://docs.signalsciences.net/using-signal-sciences/features/rules/#request-fields)
 
 <a id="nestedblock--conditions--conditions"></a>
@@ -214,7 +214,7 @@ Optional:
 - `conditions` (Block Set, Max: 10) Conditions (see [below for nested schema](#nestedblock--conditions--conditions--conditions))
 - `field` (String) type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, signal, requestHeader, queryParameter, postParameter)
 - `group_operator` (String) type: group, multival - Conditions that must be matched when evaluating the request (all, any)
-- `operator` (String) type: single - (equals, doesNotEqual, contains, doesNotContain, like, notLike, exists, doesNotExist, inList, notInList)
+- `operator` (String) type: single - (equals, doesNotEqual, contains, doesNotContain, like, notLike, exists, doesNotExist, matches, doesNotMatch, inList, notInList)
 - `value` (String) type: single - See request fields (https://docs.signalsciences.net/using-signal-sciences/features/rules/#request-fields)
 
 <a id="nestedblock--conditions--conditions--conditions"></a>

--- a/docs/resources/site_rule.md
+++ b/docs/resources/site_rule.md
@@ -228,7 +228,7 @@ Optional:
 
 - `field` (String) type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, signal, requestHeader, queryParameter, postParameter)
 - `group_operator` (String) type: group, multival - Conditions that must be matched when evaluating the request (all, any)
-- `operator` (String) type: single - (equals, doesNotEqual, contains, doesNotContain, like, notLike, exists, doesNotExist, inList, notInList)
+- `operator` (String) type: single - (equals, doesNotEqual, contains, doesNotContain, like, notLike, exists, doesNotExist, matches, doesNotMatch, inList, notInList)
 - `value` (String) type: single - See request fields (https://docs.signalsciences.net/using-signal-sciences/features/rules/#request-fields)
 
 

--- a/provider/resource_site_rule.go
+++ b/provider/resource_site_rule.go
@@ -106,7 +106,7 @@ func resourceSiteRule() *schema.Resource {
 						},
 						"operator": {
 							Type:        schema.TypeString,
-							Description: "type: single - (equals, doesNotEqual, contains, doesNotContain, like, notLike, exists, doesNotExist, inList, notInList)",
+							Description: "type: single - (equals, doesNotEqual, contains, doesNotContain, like, notLike, exists, doesNotExist, matches, doesNotMatch, inList, notInList)",
 							Optional:    true,
 						},
 						"group_operator": {
@@ -139,7 +139,7 @@ func resourceSiteRule() *schema.Resource {
 									},
 									"operator": {
 										Type:        schema.TypeString,
-										Description: "type: single - (equals, doesNotEqual, contains, doesNotContain, like, notLike, exists, doesNotExist, inList, notInList)",
+										Description: "type: single - (equals, doesNotEqual, contains, doesNotContain, like, notLike, exists, doesNotExist, matches, doesNotMatch, inList, notInList)",
 										Optional:    true,
 									},
 									"group_operator": {
@@ -172,7 +172,7 @@ func resourceSiteRule() *schema.Resource {
 												},
 												"operator": {
 													Type:        schema.TypeString,
-													Description: "type: single - (equals, doesNotEqual, contains, doesNotContain, like, notLike, exists, doesNotExist, inList, notInList)",
+													Description: "type: single - (equals, doesNotEqual, contains, doesNotContain, like, notLike, exists, doesNotExist, matches, doesNotMatch, inList, notInList)",
 													Optional:    true,
 												},
 												"group_operator": {


### PR DESCRIPTION
The [API docs](https://docs.fastly.com/signalsciences/api/#_corps__corpName__sites__siteName__rules_post) list `matches` & `doesNotMatch` as available options for the POST Create Site Rule. I've tested creating a rule with terraform that uses both operators, and it works fine.

Just adding the corrected operator list to the docs.