### PR TITLE
Add responseHeader to valid condition fields

### DIFF
--- a/provider/lib.go
+++ b/provider/lib.go
@@ -522,19 +522,19 @@ var siteImporter = schema.ResourceImporter{
 	},
 }
 
-func validateConditionField(val interface{}, key string) ([]string, []error) {
-	knownFields := []string{
-		"scheme", "method", "path", "useragent", "domain", "ip", "responseCode", "agentname",
-		"paramname", "paramvalue", "country", "name", "valueString", "valueIp", "signalType",
-		"signal", "requestHeader", "queryParameter", "postParameter", "requestCookie", "value",
-		"responseHeader",
-	}
+var KnownConditionFields = []string{
+	"scheme", "method", "path", "useragent", "domain", "ip", "responseCode", "agentname",
+	"paramname", "paramvalue", "country", "name", "valueString", "valueIp", "signalType",
+	"signal", "requestHeader", "queryParameter", "postParameter", "requestCookie", "value",
+	"responseHeader",
+}
 
-	if existsInString(val.(string), knownFields...) {
+func validateConditionField(val interface{}, key string) ([]string, []error) {
+	if existsInString(val.(string), KnownConditionFields...) {
 		return nil, nil
 	}
 
-	return []string{fmt.Sprintf("received %q for conditions.field. This is not necessarily an error, but we only know about the following values. If this is a new value, please open a PR to get it added.\n(%s)", val.(string), strings.Join(knownFields, ", "))}, nil
+	return []string{fmt.Sprintf("received %q for conditions.field. This is not necessarily an error, but we only know about the following values. If this is a new value, please open a PR to get it added.\n(%s)", val.(string), strings.Join(KnownConditionFields, ", "))}, nil
 }
 
 func validateActionResponseCode(val interface{}, key string) ([]string, []error) {

--- a/provider/lib.go
+++ b/provider/lib.go
@@ -527,6 +527,7 @@ func validateConditionField(val interface{}, key string) ([]string, []error) {
 		"scheme", "method", "path", "useragent", "domain", "ip", "responseCode", "agentname",
 		"paramname", "paramvalue", "country", "name", "valueString", "valueIp", "signalType",
 		"signal", "requestHeader", "queryParameter", "postParameter", "requestCookie", "value",
+		"responseHeader",
 	}
 
 	if existsInString(val.(string), knownFields...) {

--- a/provider/lib_test.go
+++ b/provider/lib_test.go
@@ -133,6 +133,7 @@ func TestValidateConditionField(t *testing.T) {
 		{in: "scheme"},
 		{in: "queryParameter"},
 		{in: "value"},
+		{in: "responseHeader"},
 
 		{in: "unknownconditionfield", wantErr: true},
 	}

--- a/provider/resource_corp_rule.go
+++ b/provider/resource_corp_rule.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/signalsciences/go-sigsci"
@@ -83,7 +84,7 @@ func resourceCorpRule() *schema.Resource {
 						},
 						"field": {
 							Type:         schema.TypeString,
-							Description:  "type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, signal, requestHeader, queryParameter, postParameter)",
+							Description:  fmt.Sprintf("type: single - (%s)", strings.Join(KnownConditionFields, ", ")),
 							Optional:     true,
 							ValidateFunc: validateConditionField,
 						},
@@ -117,7 +118,7 @@ func resourceCorpRule() *schema.Resource {
 									},
 									"field": {
 										Type:         schema.TypeString,
-										Description:  "type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, signal, requestHeader, queryParameter, postParameter)",
+										Description:  fmt.Sprintf("type: single - (%s)", strings.Join(KnownConditionFields, ", ")),
 										Optional:     true,
 										ValidateFunc: validateConditionField,
 									},
@@ -150,7 +151,7 @@ func resourceCorpRule() *schema.Resource {
 												},
 												"field": {
 													Type:         schema.TypeString,
-													Description:  "type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, signal, requestHeader, queryParameter, postParameter)",
+													Description:  fmt.Sprintf("type: single - (%s)", strings.Join(KnownConditionFields, ", ")),
 													Optional:     true,
 													ValidateFunc: validateConditionField,
 												},

--- a/provider/resource_site_rule.go
+++ b/provider/resource_site_rule.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/signalsciences/go-sigsci"
@@ -100,7 +101,7 @@ func resourceSiteRule() *schema.Resource {
 						},
 						"field": {
 							Type:         schema.TypeString,
-							Description:  "type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, signal, requestHeader, queryParameter, postParameter)",
+							Description:  fmt.Sprintf("type: single - (%s)", strings.Join(KnownConditionFields, ", ")),
 							Optional:     true,
 							ValidateFunc: validateConditionField,
 						},
@@ -133,7 +134,7 @@ func resourceSiteRule() *schema.Resource {
 									},
 									"field": {
 										Type:         schema.TypeString,
-										Description:  "type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, signal, requestHeader, queryParameter, postParameter)",
+										Description:  fmt.Sprintf("type: single - (%s)", strings.Join(KnownConditionFields, ", ")),
 										Optional:     true,
 										ValidateFunc: validateConditionField,
 									},
@@ -166,7 +167,7 @@ func resourceSiteRule() *schema.Resource {
 												},
 												"field": {
 													Type:         schema.TypeString,
-													Description:  "type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, signal, requestHeader, queryParameter, postParameter)",
+													Description:  fmt.Sprintf("type: single - (%s)", strings.Join(KnownConditionFields, ", ")),
 													Optional:     true,
 													ValidateFunc: validateConditionField,
 												},


### PR DESCRIPTION
This PR adds `responseHeader` to the valid condition fields. According to Fastly support and the SigSci dashboard, response headers are a valid attribute to set conditions against. The TF provider does not currently agree and the spurious warnings make it hard to debug other SigSci issues. This adds `responseHeader` to the list to prevent these warnings.

The description in the resource schemas also pull the fields from a variable now  to avoid having to keep the actual validation and the documentation in sync in six places.

----

Thank you!