### PR TITLE
DOC: update multival usage and add docs.fastly.com links

### DIFF
--- a/docs/resources/corp_integration.md
+++ b/docs/resources/corp_integration.md
@@ -32,7 +32,7 @@ resource "sigsci_corp_integration" "test_corp_integration" {
 
 ### Optional
 
-- `events` (Set of String) Array of event types. Visit https://docs.signalsciences.net/integrations to find out which events the service you are connecting allows.
+- `events` (Set of String) Array of event types. Visit https://docs.fastly.com/signalsciences/integrations to find out which events the service you are connecting allows.
 
 ### Read-Only
 

--- a/docs/resources/corp_rule.md
+++ b/docs/resources/corp_rule.md
@@ -58,6 +58,7 @@ resource "sigsci_corp_rule" "test" {
 
 ### Optional
 
+- `requestlogging` (String) Indicates whether to store the logs for requests that match the rule's conditions (sampled) or not store them (none). This field is only available for rules of type `request`. Not valid for `signal`.
 - `signal` (String) The signal id of the signal being excluded
 - `site_short_names` (Set of String) Sites with the rule available. Rules with a global corpScope will return '[]'.
 
@@ -70,7 +71,7 @@ resource "sigsci_corp_rule" "test" {
 
 Required:
 
-- `type` (String) (block, allow, exclude)
+- `type` (String) (block, allow, addSignal, excludeSignal)
 
 Optional:
 
@@ -87,7 +88,9 @@ Required:
 Optional:
 
 - `conditions` (Block Set, Max: 10) Conditions (see [below for nested schema](#nestedblock--conditions--conditions))
-- `field` (String) type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, signal, requestHeader, queryParameter, postParameter)
+- `field` (String) types:
+    - single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, value)
+    - multival - (signal, requestHeader, queryParameter, postParameter, requestCookie, responseHeader)
 - `group_operator` (String) type: group, multival - Conditions that must be matched when evaluating the request (all, any)
 - `operator` (String) type: single - (equals, doesNotEqual, contains, doesNotContain, like, notLike, exists, doesNotExist, inList, notInList)
 - `value` (String) type: single - See request fields (https://docs.signalsciences.net/using-signal-sciences/features/rules/#request-fields)
@@ -102,10 +105,12 @@ Required:
 Optional:
 
 - `conditions` (Block Set, Max: 10) Conditions (see [below for nested schema](#nestedblock--conditions--conditions--conditions))
-- `field` (String) type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, signal, requestHeader, queryParameter, postParameter)
+- `field` (String) types:
+    - single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, value)
+    - multival - (signal, requestHeader, queryParameter, postParameter, requestCookie, responseHeader)
 - `group_operator` (String) type: group, multival - Conditions that must be matched when evaluating the request (all, any)
 - `operator` (String) type: single - (equals, doesNotEqual, contains, doesNotContain, like, notLike, exists, doesNotExist, inList, notInList)
-- `value` (String) type: single - See request fields (https://docs.signalsciences.net/using-signal-sciences/features/rules/#request-fields)
+- `value` (String) type: single - See request fields (https://docs.fastly.com/signalsciences/using-signal-sciences/rules/defining-rule-conditions/#fields)
 
 <a id="nestedblock--conditions--conditions--conditions"></a>
 ### Nested Schema for `conditions.conditions.conditions`
@@ -116,10 +121,12 @@ Required:
 
 Optional:
 
-- `field` (String) type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, signal, requestHeader, queryParameter, postParameter)
+- `field` (String) types:
+    - single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, value)
+    - multival - (signal, requestHeader, queryParameter, postParameter, requestCookie, responseHeader)
 - `group_operator` (String) type: group, multival - Conditions that must be matched when evaluating the request (all, any)
 - `operator` (String) type: single - (equals, doesNotEqual, contains, doesNotContain, like, notLike, exists, doesNotExist, inList, notInList)
-- `value` (String) type: single - See request fields (https://docs.signalsciences.net/using-signal-sciences/features/rules/#request-fields)
+- `value` (String) type: single - See request fields (https://docs.fastly.com/signalsciences/using-signal-sciences/rules/defining-rule-conditions/#fields)
 
 ## Import
 

--- a/docs/resources/corp_rule.md
+++ b/docs/resources/corp_rule.md
@@ -54,7 +54,7 @@ resource "sigsci_corp_rule" "test" {
 - `expiration` (String) Date the rule will automatically be disabled. If rule is always enabled, will return empty string
 - `group_operator` (String) Conditions that must be matched when evaluating the request (all, any)
 - `reason` (String) Description of the rule
-- `type` (String) Type of rule (request, signal exclusion)
+- `type` (String) Type of rule (request, signal)
 
 ### Optional
 

--- a/docs/resources/site_integration.md
+++ b/docs/resources/site_integration.md
@@ -34,7 +34,7 @@ resource "sigsci_site_integration" "test_integration" {
 
 ### Optional
 
-- `events` (Set of String) Array of event types. Visit https://docs.signalsciences.net/integrations to find out which events the service you are connecting allows.
+- `events` (Set of String) Array of event types. Visit https://docs.fastly.com/signalsciences/integrations to find out which events the service you are connecting allows.
 
 ### Read-Only
 

--- a/docs/resources/site_rule.md
+++ b/docs/resources/site_rule.md
@@ -174,13 +174,13 @@ resource "sigsci_site_rule" "test-signal-exclusion" {
 - `group_operator` (String) Conditions that must be matched when evaluating the request (all, any)
 - `reason` (String) Description of the rule
 - `site_short_name` (String) Site short name
-- `type` (String) Type of rule (request, signal exclusion, rateLimit)
+- `type` (String) Type of rule (request, signal, rateLimit)
 
 ### Optional
 
 - `actions` (Block Set, Max: 2) Actions (see [below for nested schema](#nestedblock--actions))
 - `rate_limit` (Map of String) Rate Limit
-- `requestlogging` (String) Indicates whether to store the logs for requests that match the rule's conditions (sampled) or not store them (none). This field is only available for request rules that have a block or allow action.
+- `requestlogging` (String) Indicates whether to store the logs for requests that match the rule's conditions (sampled) or not store them (none). This field is only available for rules of type `request`. Not valid for `signal` or `rateLimit`.
 - `signal` (String) The signal id of the signal being excluded
 
 ### Read-Only
@@ -197,10 +197,12 @@ Required:
 Optional:
 
 - `conditions` (Block Set, Max: 10) Conditions (see [below for nested schema](#nestedblock--conditions--conditions))
-- `field` (String) type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, signal, requestHeader, queryParameter, postParameter)
+- `field` (String) types:
+    - single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, value)
+    - multival - (signal, requestHeader, queryParameter, postParameter, requestCookie, responseHeader)
 - `group_operator` (String) type: group, multival - Conditions that must be matched when evaluating the request (all, any)
 - `operator` (String) type: single - (equals, doesNotEqual, contains, doesNotContain, like, notLike, exists, doesNotExist, matches, doesNotMatch, inList, notInList)
-- `value` (String) type: single - See request fields (https://docs.signalsciences.net/using-signal-sciences/features/rules/#request-fields)
+- `value` (String) type: single - See request fields (https://docs.fastly.com/signalsciences/using-signal-sciences/rules/defining-rule-conditions/#fields)
 
 <a id="nestedblock--conditions--conditions"></a>
 ### Nested Schema for `conditions.conditions`
@@ -212,10 +214,12 @@ Required:
 Optional:
 
 - `conditions` (Block Set, Max: 10) Conditions (see [below for nested schema](#nestedblock--conditions--conditions--conditions))
-- `field` (String) type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, signal, requestHeader, queryParameter, postParameter)
+- `field` (String) types:
+    - single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, value)
+    - multival - (signal, requestHeader, queryParameter, postParameter, requestCookie, responseHeader)
 - `group_operator` (String) type: group, multival - Conditions that must be matched when evaluating the request (all, any)
 - `operator` (String) type: single - (equals, doesNotEqual, contains, doesNotContain, like, notLike, exists, doesNotExist, matches, doesNotMatch, inList, notInList)
-- `value` (String) type: single - See request fields (https://docs.signalsciences.net/using-signal-sciences/features/rules/#request-fields)
+- `value` (String) type: single - See request fields (https://docs.fastly.com/signalsciences/using-signal-sciences/rules/defining-rule-conditions/#fields)
 
 <a id="nestedblock--conditions--conditions--conditions"></a>
 ### Nested Schema for `conditions.conditions.conditions`
@@ -226,10 +230,12 @@ Required:
 
 Optional:
 
-- `field` (String) type: single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, signal, requestHeader, queryParameter, postParameter)
+- `field` (String) types:
+    - single - (scheme, method, path, useragent, domain, ip, responseCode, agentname, paramname, paramvalue, country, name, valueString, valueIp, signalType, value)
+    - multival - (signal, requestHeader, queryParameter, postParameter, requestCookie, responseHeader)
 - `group_operator` (String) type: group, multival - Conditions that must be matched when evaluating the request (all, any)
 - `operator` (String) type: single - (equals, doesNotEqual, contains, doesNotContain, like, notLike, exists, doesNotExist, matches, doesNotMatch, inList, notInList)
-- `value` (String) type: single - See request fields (https://docs.signalsciences.net/using-signal-sciences/features/rules/#request-fields)
+- `value` (String) type: single - See request fields (https://docs.fastly.com/signalsciences/using-signal-sciences/rules/defining-rule-conditions/#fields)
 
 
 

--- a/provider/lib.go
+++ b/provider/lib.go
@@ -522,19 +522,23 @@ var siteImporter = schema.ResourceImporter{
 	},
 }
 
-var KnownConditionFields = []string{
+var KnownSingleConditionFields = []string{
 	"scheme", "method", "path", "useragent", "domain", "ip", "responseCode", "agentname",
 	"paramname", "paramvalue", "country", "name", "valueString", "valueIp", "signalType",
-	"signal", "requestHeader", "queryParameter", "postParameter", "requestCookie", "value",
+	"value",
+}
+
+var KnownMultivalConditionFields = []string{
+	"signal", "requestHeader", "queryParameter", "postParameter", "requestCookie",
 	"responseHeader",
 }
 
 func validateConditionField(val interface{}, key string) ([]string, []error) {
-	if existsInString(val.(string), KnownConditionFields...) {
+	if existsInString(val.(string), KnownSingleConditionFields...) || existsInString(val.(string), KnownMultivalConditionFields...) {
 		return nil, nil
 	}
 
-	return []string{fmt.Sprintf("received %q for conditions.field. This is not necessarily an error, but we only know about the following values. If this is a new value, please open a PR to get it added.\n(%s)", val.(string), strings.Join(KnownConditionFields, ", "))}, nil
+	return []string{fmt.Sprintf("received %q for conditions.field. This is not necessarily an error, but we only know about the following values. If this is a new value, please open a PR to get it added.\n(%s)", val.(string), strings.Join(append(KnownSingleConditionFields, KnownMultivalConditionFields...), ", "))}, nil
 }
 
 func validateActionResponseCode(val interface{}, key string) ([]string, []error) {

--- a/provider/resource_corp_integration.go
+++ b/provider/resource_corp_integration.go
@@ -37,7 +37,7 @@ func resourceCorpIntegration() *schema.Resource {
 			},
 			"events": {
 				Type:        schema.TypeSet,
-				Description: "Array of event types. Visit https://docs.signalsciences.net/integrations to find out which events the service you are connecting allows.",
+				Description: "Array of event types. Visit https://docs.fastly.com/signalsciences/integrations to find out which events the service you are connecting allows.",
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},

--- a/provider/resource_corp_rule.go
+++ b/provider/resource_corp_rule.go
@@ -27,7 +27,7 @@ func resourceCorpRule() *schema.Resource {
 			"type": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "Type of rule (request, signal exclusion)",
+				Description: "Type of rule (request, signal)",
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 					if existsInString(val.(string), "request", "signal") {
 						return nil, nil

--- a/provider/resource_corp_rule.go
+++ b/provider/resource_corp_rule.go
@@ -29,7 +29,7 @@ func resourceCorpRule() *schema.Resource {
 				Required:    true,
 				Description: "Type of rule (request, signal exclusion)",
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-					if existsInString(val.(string), "request", "signal", "exclusion") {
+					if existsInString(val.(string), "request", "signal") {
 						return nil, nil
 					}
 					return nil, []error{}
@@ -59,7 +59,7 @@ func resourceCorpRule() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"type": {
 							Type:        schema.TypeString,
-							Description: "(block, allow, exclude)",
+							Description: "(block, allow, addSignal, excludeSignal)",
 							Required:    true,
 						},
 						"signal": {
@@ -84,7 +84,7 @@ func resourceCorpRule() *schema.Resource {
 						},
 						"field": {
 							Type:         schema.TypeString,
-							Description:  fmt.Sprintf("type: single - (%s)", strings.Join(KnownConditionFields, ", ")),
+							Description:  fmt.Sprintf("types:\n    - single - (%s)\n    - multival - (%s)", strings.Join(KnownSingleConditionFields, ", "), strings.Join(KnownMultivalConditionFields, ", ")),
 							Optional:     true,
 							ValidateFunc: validateConditionField,
 						},
@@ -118,7 +118,7 @@ func resourceCorpRule() *schema.Resource {
 									},
 									"field": {
 										Type:         schema.TypeString,
-										Description:  fmt.Sprintf("type: single - (%s)", strings.Join(KnownConditionFields, ", ")),
+										Description:  fmt.Sprintf("types:\n    - single - (%s)\n    - multival - (%s)", strings.Join(KnownSingleConditionFields, ", "), strings.Join(KnownMultivalConditionFields, ", ")),
 										Optional:     true,
 										ValidateFunc: validateConditionField,
 									},
@@ -134,7 +134,7 @@ func resourceCorpRule() *schema.Resource {
 									},
 									"value": {
 										Type:        schema.TypeString,
-										Description: "type: single - See request fields (https://docs.signalsciences.net/using-signal-sciences/features/rules/#request-fields)",
+										Description: "type: single - See request fields (https://docs.fastly.com/signalsciences/using-signal-sciences/rules/defining-rule-conditions/#fields)",
 										Optional:    true,
 									},
 									"conditions": {
@@ -151,7 +151,7 @@ func resourceCorpRule() *schema.Resource {
 												},
 												"field": {
 													Type:         schema.TypeString,
-													Description:  fmt.Sprintf("type: single - (%s)", strings.Join(KnownConditionFields, ", ")),
+													Description:  fmt.Sprintf("types:\n    - single - (%s)\n    - multival - (%s)", strings.Join(KnownSingleConditionFields, ", "), strings.Join(KnownMultivalConditionFields, ", ")),
 													Optional:     true,
 													ValidateFunc: validateConditionField,
 												},
@@ -167,7 +167,7 @@ func resourceCorpRule() *schema.Resource {
 												},
 												"value": {
 													Type:        schema.TypeString,
-													Description: "type: single - See request fields (https://docs.signalsciences.net/using-signal-sciences/features/rules/#request-fields)",
+													Description: "type: single - See request fields (https://docs.fastly.com/signalsciences/using-signal-sciences/rules/defining-rule-conditions/#fields)",
 													Optional:    true,
 												},
 											},
@@ -178,6 +178,11 @@ func resourceCorpRule() *schema.Resource {
 						},
 					},
 				},
+			},
+			"requestlogging": {
+				Type:        schema.TypeString,
+				Description: "Indicates whether to store the logs for requests that match the rule's conditions (sampled) or not store them (none). This field is only available for rules of type `request`. Not valid for `signal`.",
+				Optional:    true,
 			},
 			"signal": {
 				Type:        schema.TypeString,
@@ -197,6 +202,7 @@ func resourceCorpRule() *schema.Resource {
 		},
 	}
 }
+
 func resourceCorpRuleCreate(d *schema.ResourceData, m interface{}) error {
 	pm := m.(providerMetadata)
 	sc := pm.Client
@@ -248,6 +254,7 @@ func resourceCorpRuleUpdate(d *schema.ResourceData, m interface{}) error {
 	}
 	return resourceCorpRuleRead(d, m)
 }
+
 func resourceCorpRuleRead(d *schema.ResourceData, m interface{}) error {
 	pm := m.(providerMetadata)
 	sc := pm.Client
@@ -301,6 +308,7 @@ func resourceCorpRuleRead(d *schema.ResourceData, m interface{}) error {
 	}
 	return nil
 }
+
 func resourceCorpRuleDelete(d *schema.ResourceData, m interface{}) error {
 	pm := m.(providerMetadata)
 	sc := pm.Client

--- a/provider/resource_site_integration.go
+++ b/provider/resource_site_integration.go
@@ -34,7 +34,7 @@ func resourceSiteIntegration() *schema.Resource {
 			},
 			"events": {
 				Type:        schema.TypeSet,
-				Description: "Array of event types. Visit https://docs.signalsciences.net/integrations to find out which events the service you are connecting allows.",
+				Description: "Array of event types. Visit https://docs.fastly.com/signalsciences/integrations to find out which events the service you are connecting allows.",
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},

--- a/provider/resource_site_rule.go
+++ b/provider/resource_site_rule.go
@@ -20,7 +20,7 @@ func resourceSiteRule() *schema.Resource {
 			},
 			"type": {
 				Type:        schema.TypeString,
-				Description: "Type of rule (request, signal exclusion, rateLimit)",
+				Description: "Type of rule (request, signal, rateLimit)",
 				Required:    true,
 			},
 			"group_operator": {
@@ -50,7 +50,7 @@ func resourceSiteRule() *schema.Resource {
 			},
 			"requestlogging": {
 				Type:        schema.TypeString,
-				Description: "Indicates whether to store the logs for requests that match the rule's conditions (sampled) or not store them (none). This field is only available for request rules that have a block or allow action.",
+				Description: "Indicates whether to store the logs for requests that match the rule's conditions (sampled) or not store them (none). This field is only available for rules of type `request`. Not valid for `signal` or `rateLimit`.",
 				Optional:    true,
 			},
 			"actions": {
@@ -101,7 +101,7 @@ func resourceSiteRule() *schema.Resource {
 						},
 						"field": {
 							Type:         schema.TypeString,
-							Description:  fmt.Sprintf("type: single - (%s)", strings.Join(KnownConditionFields, ", ")),
+							Description:  fmt.Sprintf("types:\n    - single - (%s)\n    - multival - (%s)", strings.Join(KnownSingleConditionFields, ", "), strings.Join(KnownMultivalConditionFields, ", ")),
 							Optional:     true,
 							ValidateFunc: validateConditionField,
 						},
@@ -117,7 +117,7 @@ func resourceSiteRule() *schema.Resource {
 						},
 						"value": {
 							Type:        schema.TypeString,
-							Description: "type: single - See request fields (https://docs.signalsciences.net/using-signal-sciences/features/rules/#request-fields)",
+							Description: "type: single - See request fields (https://docs.fastly.com/signalsciences/using-signal-sciences/rules/defining-rule-conditions/#fields)",
 							Optional:    true,
 						},
 						"conditions": {
@@ -134,7 +134,7 @@ func resourceSiteRule() *schema.Resource {
 									},
 									"field": {
 										Type:         schema.TypeString,
-										Description:  fmt.Sprintf("type: single - (%s)", strings.Join(KnownConditionFields, ", ")),
+										Description:  fmt.Sprintf("types:\n    - single - (%s)\n    - multival - (%s)", strings.Join(KnownSingleConditionFields, ", "), strings.Join(KnownMultivalConditionFields, ", ")),
 										Optional:     true,
 										ValidateFunc: validateConditionField,
 									},
@@ -150,7 +150,7 @@ func resourceSiteRule() *schema.Resource {
 									},
 									"value": {
 										Type:        schema.TypeString,
-										Description: "type: single - See request fields (https://docs.signalsciences.net/using-signal-sciences/features/rules/#request-fields)",
+										Description: "type: single - See request fields (https://docs.fastly.com/signalsciences/using-signal-sciences/rules/defining-rule-conditions/#fields)",
 										Optional:    true,
 									},
 									"conditions": {
@@ -167,7 +167,7 @@ func resourceSiteRule() *schema.Resource {
 												},
 												"field": {
 													Type:         schema.TypeString,
-													Description:  fmt.Sprintf("type: single - (%s)", strings.Join(KnownConditionFields, ", ")),
+													Description:  fmt.Sprintf("types:\n    - single - (%s)\n    - multival - (%s)", strings.Join(KnownSingleConditionFields, ", "), strings.Join(KnownMultivalConditionFields, ", ")),
 													Optional:     true,
 													ValidateFunc: validateConditionField,
 												},
@@ -183,7 +183,7 @@ func resourceSiteRule() *schema.Resource {
 												},
 												"value": {
 													Type:        schema.TypeString,
-													Description: "type: single - See request fields (https://docs.signalsciences.net/using-signal-sciences/features/rules/#request-fields)",
+													Description: "type: single - See request fields (https://docs.fastly.com/signalsciences/using-signal-sciences/rules/defining-rule-conditions/#fields)",
 													Optional:    true,
 												},
 											},
@@ -262,7 +262,6 @@ func resourceSiteRuleCreate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceSiteRuleRead(d *schema.ResourceData, m interface{}) error {
-
 	pm := m.(providerMetadata)
 	sc := pm.Client
 	corp := pm.Corp
@@ -323,7 +322,6 @@ func resourceSiteRuleRead(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceSiteRuleUpdate(d *schema.ResourceData, m interface{}) error {
-
 	pm := m.(providerMetadata)
 	sc := pm.Client
 	corp := pm.Corp


### PR DESCRIPTION
This commit updates the documenation with the following changes:

* Replaces docs.signalsciences.net with proper docs.fastly.com URLs
* Splits `field` types into "single" and "multival" with the valid values for each
* Expands requestlogging to indicate that it is only valid for rules of type "request" and explicitly calls out that it is not valid for "signal" or "rateLimit"
* Fixes "signal exclusion" to be "signal"
* Fixes corp rule types to have addSignal, excludeSignal