### PR TITLE
BUG/MINOR: rules: suppress requestLogging default

### DIFF
--- a/provider/lib.go
+++ b/provider/lib.go
@@ -15,6 +15,13 @@ func suppressEquivalentTrimSpaceDiffs(k, old, new string, d *schema.ResourceData
 	return strings.TrimSpace(old) == strings.TrimSpace(new)
 }
 
+func suppressRequestLoggingDefaultDiffs(k, old, new string, d *schema.ResourceData) bool {
+	if old == "" && new == "sampled" {
+		return true
+	}
+	return false
+}
+
 type providerMetadata struct {
 	Corp   string
 	Client sigsci.Client

--- a/provider/resource_corp_rule.go
+++ b/provider/resource_corp_rule.go
@@ -180,9 +180,10 @@ func resourceCorpRule() *schema.Resource {
 				},
 			},
 			"requestlogging": {
-				Type:        schema.TypeString,
-				Description: "Indicates whether to store the logs for requests that match the rule's conditions (sampled) or not store them (none). This field is only available for rules of type `request`. Not valid for `signal`.",
-				Optional:    true,
+				Type:             schema.TypeString,
+				Description:      "Indicates whether to store the logs for requests that match the rule's conditions (sampled) or not store them (none). This field is only available for rules of type `request`. Not valid for `signal`.",
+				Optional:         true,
+				DiffSuppressFunc: suppressRequestLoggingDefaultDiffs,
 			},
 			"signal": {
 				Type:        schema.TypeString,

--- a/provider/resource_site_rule.go
+++ b/provider/resource_site_rule.go
@@ -49,9 +49,10 @@ func resourceSiteRule() *schema.Resource {
 				Required:    true,
 			},
 			"requestlogging": {
-				Type:        schema.TypeString,
-				Description: "Indicates whether to store the logs for requests that match the rule's conditions (sampled) or not store them (none). This field is only available for rules of type `request`. Not valid for `signal` or `rateLimit`.",
-				Optional:    true,
+				Type:             schema.TypeString,
+				Description:      "Indicates whether to store the logs for requests that match the rule's conditions (sampled) or not store them (none). This field is only available for rules of type `request`. Not valid for `signal` or `rateLimit`.",
+				Optional:         true,
+				DiffSuppressFunc: suppressRequestLoggingDefaultDiffs,
 			},
 			"actions": {
 				Type:        schema.TypeSet,


### PR DESCRIPTION
requestLogging is an optional parameter that can be specified within request rules. It defaults to "sampled", however, if you create a rule without specifying it, it can cause terraform to mark a change as happening even though one was not expected. e.g.

```
      + requestlogging  = "sampled"
```

In other situations, we could just set the default in the provider to be "sampled". However, because requestLogging is not valid with all rule types and at the time of this commit terraform does not allow you to do pre-validation on multiple fields.

For this reason, we need to use `DiffSuppressFunc` to ignore the diff if `requestLogging` was not specified but the API responded with `sampled`.