### PR TITLE
BUG/MAJOR: redactions: fix redactiontype key name

### DIFF
--- a/docs/resources/site_redaction.md
+++ b/docs/resources/site_redaction.md
@@ -15,7 +15,7 @@ description: |-
 resource "sigsci_site_redaction" "test" {
   site_short_name = sigsci_site.my-site.short_name
   field           = "redacted"
-  redaction_type  = 0
+  redactiontype   = 0
 }
 ```
 
@@ -28,7 +28,7 @@ resource "sigsci_site_redaction" "test" {
 ### Required
 
 - `field` (String) Field Name
-- `redaction_type` (Number) Type of redaction (0: Request Parameter, 1: Request Header, 2: Response Header)
+- `redactiontype` (Number) Type of redaction (0: Request Parameter, 1: Request Header, 2: Response Header)
 - `site_short_name` (String) Site short name
 
 ### Read-Only

--- a/examples/resources/sigsci_site_redaction/resource.tf
+++ b/examples/resources/sigsci_site_redaction/resource.tf
@@ -1,5 +1,5 @@
 resource "sigsci_site_redaction" "test" {
   site_short_name = sigsci_site.my-site.short_name
   field           = "redacted"
-  redaction_type  = 0
+  redactiontype   = 0
 }

--- a/main.tf
+++ b/main.tf
@@ -210,7 +210,7 @@ resource "sigsci_site_allowlist" "test" {
 resource "sigsci_site_redaction" "test_redaction" {
   site_short_name = sigsci_site.my-site.short_name
   field           = "redacted"
-  redaction_type  = 0
+  redactiontype   = 0
 }
 
 resource "sigsci_site_rule" "testt" {

--- a/provider/resource_site_redaction.go
+++ b/provider/resource_site_redaction.go
@@ -29,7 +29,7 @@ func resourceSiteRedaction() *schema.Resource {
 					return strings.EqualFold(old, new)
 				},
 			},
-			"redaction_type": {
+			"redactiontype": {
 				Type:        schema.TypeInt,
 				Description: "Type of redaction (0: Request Parameter, 1: Request Header, 2: Response Header)",
 				Required:    true,
@@ -44,7 +44,7 @@ func resourceSiteRedactionCreate(d *schema.ResourceData, m interface{}) error {
 
 	redaction, err := sc.CreateSiteRedaction(pm.Corp, d.Get("site_short_name").(string), sigsci.CreateSiteRedactionBody{
 		Field:         d.Get("field").(string),
-		RedactionType: d.Get("redaction_type").(int),
+		RedactionType: d.Get("redactiontype").(int),
 	})
 	if err != nil {
 		return err
@@ -72,7 +72,7 @@ func resourceSiteRedactionRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	err = d.Set("redaction_type", redaction.RedactionType)
+	err = d.Set("redactiontype", redaction.RedactionType)
 	if err != nil {
 		return err
 	}
@@ -85,7 +85,7 @@ func resourceSiteRedactionUpdate(d *schema.ResourceData, m interface{}) error {
 
 	redaction, err := sc.UpdateSiteRedactionByID(pm.Corp, d.Get("site_short_name").(string), d.Id(), sigsci.CreateSiteRedactionBody{
 		Field:         d.Get("field").(string),
-		RedactionType: d.Get("redaction_type").(int),
+		RedactionType: d.Get("redactiontype").(int),
 	})
 	if err != nil {
 		d.SetId("")

--- a/provider/resource_site_redaction_test.go
+++ b/provider/resource_site_redaction_test.go
@@ -20,12 +20,12 @@ func TestAccResourceSiteRedactionCRUD(t *testing.T) {
                     resource "sigsci_site_redaction" "test_redaction" {
                       site_short_name    = "%s" 
                       field              = "field"
-                      redaction_type     = 0
+                      redactiontype      = 0
 				}`, testSite),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "site_short_name", testSite),
 					resource.TestCheckResourceAttr(resourceName, "field", "field"),
-					resource.TestCheckResourceAttr(resourceName, "redaction_type", "0"),
+					resource.TestCheckResourceAttr(resourceName, "redactiontype", "0"),
 				),
 			},
 			{
@@ -33,12 +33,12 @@ func TestAccResourceSiteRedactionCRUD(t *testing.T) {
                      resource "sigsci_site_redaction" "test_redaction" {
                       site_short_name    = "%s" 
                       field              = "field 2"
-                      redaction_type     = 1
+                      redactiontype      = 1
 				}`, testSite),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "site_short_name", testSite),
 					resource.TestCheckResourceAttr(resourceName, "field", "field 2"),
-					resource.TestCheckResourceAttr(resourceName, "redaction_type", "1"),
+					resource.TestCheckResourceAttr(resourceName, "redactiontype", "1"),
 				),
 			},
 			{


### PR DESCRIPTION
There's been an issue with redactions due to the key name being set to redaction_type when the actual API key name is redactiontype [1]. This commit updates it along with all of the references within examples to be the correct name, redactiontype. Without this change the current redaction logic does not appear to work at all.

[1] https://docs.fastly.com/signalsciences/api/#_corps__corpName__sites__siteName__redactions_post