### PR TITLE
BUG/MINOR: rules: suppress requestLogging default (again)

### DIFF
--- a/provider/lib.go
+++ b/provider/lib.go
@@ -16,7 +16,7 @@ func suppressEquivalentTrimSpaceDiffs(k, old, new string, d *schema.ResourceData
 }
 
 func suppressRequestLoggingDefaultDiffs(k, old, new string, d *schema.ResourceData) bool {
-	if old == "" && new == "sampled" {
+	if new == "" && old == "sampled" {
 		return true
 	}
 	return false


### PR DESCRIPTION
In e293b90 (BUG/MINOR: rules: suppress requestLogging default), an attempt to suppress the diff creation when requestlogging was not specified (e.g. default) was made. However, it seems that the patch confused "new" and "old" values. This commit properly swaps the order and produces the expected results.