### PR TITLE
docs: remove gopath and specify min go version constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Requirements
 * [Terraform](https://www.terraform.io/downloads.html) > 0.12.x
-* [Go](https://golang.org/doc/install) 1.17
+* [Go](https://golang.org/doc/install) 1.18
 
 Check out the [Terraform Documentation](https://www.terraform.io/docs/configuration/index.html) and their [Introduction](https://www.terraform.io/intro/index.html) for more information on terraform
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ You may find prebuilt binaries in our [Releases](https://github.com/signalscienc
 
 If you wish to build from source, first make the correct directory, cd to it, and checkout the repo.  Running `make build` will then build the provider and output it to terraform-provider-sigsci
 ```shell script
-mkdir -p $GOPATH/src/github.com/signalsciences/
-cd $GOPATH/src/github.com/signalsciences/
 git clone git@github.com:signalsciences/terraform-provider-sigsci.git
 cd terraform-provider-sigsci
 make build

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ description: |-
 
 ## Requirements
 * [Terraform](https://www.terraform.io/downloads.html) 0.12.x, 0.13.x
-* [Go](https://golang.org/doc/install) 1.14
+* [Go](https://golang.org/doc/install) 1.18
 
 ## Building the provider
 Build with make and the resulting binary will be terraform-provider-sigsci.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 page_title: "sigsci Provider"
 subcategory: ""
 description: |-
-  
+
 ---
 
 ## Requirements
@@ -14,10 +14,8 @@ Build with make and the resulting binary will be terraform-provider-sigsci.
 
 First make the correct directory, cd to it, and checkout the repo.  make build will then build the provider and output it to terraform-provider-sigsci
 ```shell script
-mkdir -p $GOPATH/src/github.com/signalsciences/terraform-provider-sigsci
-cd $GOPATH/src/github.com/signalsciences/terraform-provider-sigsci
 git clone git@github.com:signalsciences/terraform-provider-sigsci.git
-make build
+cd terraform-provider-sigsci && make build
 ```
 
 # sigsci Provider

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -7,7 +7,7 @@ description: |-
 
 ## Requirements
 * [Terraform](https://www.terraform.io/downloads.html) 0.12.x, 0.13.x
-* [Go](https://golang.org/doc/install) 1.14
+* [Go](https://golang.org/doc/install) 1.18
 
 ## Building the provider
 Build with make and the resulting binary will be terraform-provider-sigsci.

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -14,10 +14,8 @@ Build with make and the resulting binary will be terraform-provider-sigsci.
 
 First make the correct directory, cd to it, and checkout the repo.  make build will then build the provider and output it to terraform-provider-sigsci
 ```shell script
-mkdir -p $GOPATH/src/github.com/signalsciences/terraform-provider-sigsci
-cd $GOPATH/src/github.com/signalsciences/terraform-provider-sigsci
 git clone git@github.com:signalsciences/terraform-provider-sigsci.git
-make build
+cd terraform-provider-sigsci && make build
 ```
 
 # {{.ProviderShortName}} Provider


### PR DESCRIPTION
since the project is already go modules based, there is no need to have references for GOPATH