### PR TITLE
DOC: response code is only valid for block action

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 page_title: "sigsci Provider"
 subcategory: ""
 description: |-
-
+  
 ---
 
 ## Requirements

--- a/docs/resources/site_rule.md
+++ b/docs/resources/site_rule.md
@@ -250,7 +250,7 @@ Required:
 Optional:
 
 - `redirect_url` (String) URL to redirect to when blocking response code is set to 301 or 302
-- `response_code` (Number) HTTP code agent for agent to respond with. range: 301, 302, or 400-599, defaults to '406' if not provided
+- `response_code` (Number) HTTP code agent for agent to respond with. range: 301, 302, or 400-599, defaults to '406' if not provided. Only valid with the 'block' action type.
 - `signal` (String) signal id to tag
 
 ### Templated Signals

--- a/provider/resource_site_rule.go
+++ b/provider/resource_site_rule.go
@@ -74,7 +74,7 @@ func resourceSiteRule() *schema.Resource {
 						},
 						"response_code": {
 							Type:         schema.TypeInt,
-							Description:  "HTTP code agent for agent to respond with. range: 301, 302, or 400-599, defaults to '406' if not provided",
+							Description:  "HTTP code agent for agent to respond with. range: 301, 302, or 400-599, defaults to '406' if not provided. Only valid with the 'block' action type.",
 							Optional:     true,
 							ValidateFunc: validateActionResponseCode,
 							Default:      http.StatusNotAcceptable,


### PR DESCRIPTION
`response_code` is for setting the response code to use when blocking a request and is not valid for any other action types. Let's indicate this in the documentation to avoid confusion.