### PR TITLE
BUG/MINOR: do not set default response code

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 page_title: "sigsci Provider"
 subcategory: ""
 description: |-
-
+  
 ---
 
 ## Requirements

--- a/docs/resources/site_rule.md
+++ b/docs/resources/site_rule.md
@@ -250,7 +250,7 @@ Required:
 Optional:
 
 - `redirect_url` (String) URL to redirect to when blocking response code is set to 301 or 302
-- `response_code` (Number) HTTP code agent for agent to respond with. range: 301, 302, or 400-599, defaults to '406' if not provided
+- `response_code` (Number) HTTP code agent for agent to respond with. range: 301, 302, or 400-599, defaults to '406' if not provided. Only valid with the 'block' action type.
 - `signal` (String) signal id to tag
 
 ### Templated Signals

--- a/provider/resource_site_rule.go
+++ b/provider/resource_site_rule.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"fmt"
-	"net/http"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -74,10 +73,9 @@ func resourceSiteRule() *schema.Resource {
 						},
 						"response_code": {
 							Type:         schema.TypeInt,
-							Description:  "HTTP code agent for agent to respond with. range: 301, 302, or 400-599, defaults to '406' if not provided",
+							Description:  "HTTP code agent for agent to respond with. range: 301, 302, or 400-599, defaults to '406' if not provided. Only valid with the 'block' action type.",
 							Optional:     true,
 							ValidateFunc: validateActionResponseCode,
-							Default:      http.StatusNotAcceptable,
 						},
 						"redirect_url": {
 							Type:         schema.TypeString,


### PR DESCRIPTION
`response_code` is only valid for for the `block` action. By setting a default it forces it to be set for all action types including those that it is not valid for. When `response_code` is empty on a blocking action the API just defaults to using the site default (e.g. 406).

This commit removes the default from the Terraform provider for `response_code` and also updates the documentation to indicate that it is only valid for the `block` action type.