### PR TITLE
change: `FASTLY_KEY` rename to `FASTLY_API_KEY`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ terraform {
 
 # Required configuration block (for all versions of terraform)
 provider "sigsci" {
-  //  corp = ""       // Required. may also provide via env variable SIGSCI_CORP
-  //  email = ""      // Required. may also provide via env variable SIGSCI_EMAIL
-  //  auth_token = "" // May also provide via env variable SIGSCI_TOKEN
-  //  password = ""   // May also provide via env variable SIGSCI_PASSWORD
-  //  fastly_key = "" // May also provide via env variable FASTLY_KEY. Required for Edge Deployments functionality.
+  //  corp           = "" // Required. may also provide via env variable SIGSCI_CORP
+  //  email          = "" // Required. may also provide via env variable SIGSCI_EMAIL
+  //  auth_token     = "" // May also provide via env variable SIGSCI_TOKEN
+  //  password       = "" // May also provide via env variable SIGSCI_PASSWORD
+  //  fastly_api_key = "" // May also provide via env variable FASTLY_API_KEY. Required for Edge Deployments functionality.
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ provider "sigsci" {
   email = "" // Required. may also provide via env variable SIGSCI_EMAIL
   //  auth_token = "" // May also provide via env variable SIGSCI_TOKEN
   //  password = ""   // May also provide via env variable SIGSCI_PASSWORD
-  //  fastly_key = "" // May also provide via env variable FASTLY_KEY. Required for Edge Deployments functionality.
+  //  fastly_api_key = "" // May also provide via env variable FASTLY_API_KEY. Required for Edge Deployments functionality.
 }
 ```
 
@@ -44,7 +44,7 @@ provider "sigsci" {
 
 - `api_url` (String) URL override for testing
 - `auth_token` (String, Sensitive) The token used for authentication specify either the password or the token
-- `fastly_key` (String, Sensitive) The Fastly API key used for deploying Signal Sciences as a Fastly edge security service. For edge deployment service       calls, the Fastly key must have write access to the given service.
+- `fastly_api_key` (String, Sensitive) The Fastly API key used for deploying Signal Sciences as a Fastly edge security service. For edge deployment service calls, the Fastly key must have write access to the given service.
 - `password` (String, Sensitive) The password used to for authentication specify either the password or the token
 - `validate` (Bool) Enable validation of API credentials during provider initialization. Default is true
 

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,5 +3,5 @@ provider "sigsci" {
   email = "" // Required. may also provide via env variable SIGSCI_EMAIL
   //  auth_token = "" // May also provide via env variable SIGSCI_TOKEN
   //  password = ""   // May also provide via env variable SIGSCI_PASSWORD
-  //  fastly_key = "" // May also provide via env variable FASTLY_KEY. Required for Edge Deployments functionality.
+  //  fastly_key = "" // May also provide via env variable FASTLY_API_KEY. Required for Edge Deployments functionality.
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,5 +3,5 @@ provider "sigsci" {
   email = "" // Required. may also provide via env variable SIGSCI_EMAIL
   //  auth_token = "" // May also provide via env variable SIGSCI_TOKEN
   //  password = ""   // May also provide via env variable SIGSCI_PASSWORD
-  //  fastly_key = "" // May also provide via env variable FASTLY_API_KEY. Required for Edge Deployments functionality.
+  //  fastly_api_key = "" // May also provide via env variable FASTLY_API_KEY. Required for Edge Deployments functionality.
 }

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ provider "sigsci" {
   //  email = ""      // Required. may also provide via env variable SIGSCI_EMAIL
   //  auth_token = "" //may also provide via env variable SIGSCI_TOKEN
   //  password = ""   //may also provide via env variable SIGSCI_PASSWORD
-  //  fastly_key = ""  //may also provide via env variable FASTLY_KEY. Required for Edge Deployments functionality.
+  //  fastly_api_key = ""  //may also provide via env variable FASTLY_API_KEY. Required for Edge Deployments functionality.
 }
 
 ############# Corp Level Resources #############

--- a/provider/config.go
+++ b/provider/config.go
@@ -8,11 +8,11 @@ import (
 
 // Config struct for email and password
 type Config struct {
-	URL       string
-	Email     string
-	Password  string
-	APIToken  string
-	FastlyKey string
+	URL          string
+	Email        string
+	Password     string
+	APIToken     string
+	FastlyAPIKey string
 }
 
 // Client returns a signal science client
@@ -43,8 +43,8 @@ func (c *Config) Client() (interface{}, error) {
 		}
 	}
 
-	if c.FastlyKey != "" {
-		client.SetFastlyKey(c.FastlyKey)
+	if c.FastlyAPIKey != "" {
+		client.SetFastlyKey(c.FastlyAPIKey)
 	}
 
 	return client, nil

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -38,10 +38,10 @@ func Provider() terraform.ResourceProvider {
 				Sensitive:    true,
 				AtLeastOneOf: []string{"password", "auth_token"},
 			},
-			"fastly_key": {
+			"fastly_api_key": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("FASTLY_KEY", nil),
+				DefaultFunc: schema.EnvDefaultFunc("FASTLY_API_KEY", nil),
 				Description: "The Fastly API key used for deploying Signal Sciences as a Fastly edge security service. For edge deployment service calls, the Fastly key must have write access to the given service.",
 				Sensitive:   true,
 			},
@@ -92,11 +92,11 @@ func Provider() terraform.ResourceProvider {
 func providerConfigure() schema.ConfigureFunc {
 	return func(d *schema.ResourceData) (interface{}, error) {
 		config := Config{
-			Email:     d.Get("email").(string),
-			Password:  d.Get("password").(string),
-			APIToken:  d.Get("auth_token").(string),
-			FastlyKey: d.Get("fastly_key").(string),
-			URL:       d.Get("api_url").(string),
+			Email:        d.Get("email").(string),
+			Password:     d.Get("password").(string),
+			APIToken:     d.Get("auth_token").(string),
+			FastlyAPIKey: d.Get("fastly_api_key").(string),
+			URL:          d.Get("api_url").(string),
 		}
 		client, err := config.Client()
 		if err != nil {

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -38,7 +38,7 @@ cd terraform-provider-sigsci && make build
 
 - `api_url` (String) URL override for testing
 - `auth_token` (String, Sensitive) The token used for authentication specify either the password or the token
-- `fastly_api_key` (String, Sensitive) The Fastly API key used for deploying Signal Sciences as a Fastly edge security service. For edge deployment service       calls, the Fastly key must have write access to the given service.
+- `fastly_api_key` (String, Sensitive) The Fastly API key used for deploying Signal Sciences as a Fastly edge security service. For edge deployment service calls, the Fastly key must have write access to the given service.
 - `password` (String, Sensitive) The password used to for authentication specify either the password or the token
 - `validate` (Bool) Enable validation of API credentials during provider initialization. Default is true
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -38,7 +38,7 @@ cd terraform-provider-sigsci && make build
 
 - `api_url` (String) URL override for testing
 - `auth_token` (String, Sensitive) The token used for authentication specify either the password or the token
-- `fastly_key` (String, Sensitive) The Fastly API key used for deploying Signal Sciences as a Fastly edge security service. For edge deployment service       calls, the Fastly key must have write access to the given service.
+- `fastly_api_key` (String, Sensitive) The Fastly API key used for deploying Signal Sciences as a Fastly edge security service. For edge deployment service       calls, the Fastly key must have write access to the given service.
 - `password` (String, Sensitive) The password used to for authentication specify either the password or the token
 - `validate` (Bool) Enable validation of API credentials during provider initialization. Default is true
 


### PR DESCRIPTION
Hi, 

I renamed `FASTLY_KEY` to `FASTLY_API_KEY`. Because it's useful when using [terraform-provider-fastly](https://github.com/fastly/terraform-provider-fastly) and [terraform-provider-sigsci](https://github.com/signalsciences/terraform-provider-sigsci) in same project. For example, you can unitifaction credentials set in CI/CD.

ref. 
- terraform-provider-fastly
    - https://github.com/fastly/terraform-provider-fastly/blob/0927a692f90c6614fa8fc87aacdc60704a70a403/fastly/provider.go#L21-L26
- Isssue
    - https://github.com/signalsciences/terraform-provider-sigsci/issues/188