### PR TITLE
MINOR: main: comment edge deployment by default

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -402,13 +402,13 @@ cX4iWLb38v7KEornZfofXEw=
 PRIVATEKEY
 }
 
-resource "sigsci_edge_deployment" "edge" {
-  site_short_name = sigsci_site.my-site.short_name
-}
+#resource "sigsci_edge_deployment" "edge" {
+#  site_short_name = sigsci_site.my-site.short_name
+#}
 
-resource "sigsci_edge_deployment_service" "edge" {
-  site_short_name  = sigsci_site.my-site.short_name
-  fastly_sid       = "[Fastly service id]"
-  activate_version = true
-  percent_enabled  = 100
-}
+#resource "sigsci_edge_deployment_service" "edge" {
+#  site_short_name  = sigsci_site.my-site.short_name
+#  fastly_sid       = "[Fastly service id]"
+#  activate_version = true
+#  percent_enabled  = 100
+#}


### PR DESCRIPTION
It's been reported that some users are starting with the default main.tf This leads to having one of their sites erroneously configured as being an Edge deployment. This commit comments out the edge deployment, which allows it to be referenced but prevents their site from being configured as an Edge deployment unless they want it to.