### PR TITLE
BUG/MEDIUM: rules: add redirect_url when flattening

### DIFF
--- a/provider/lib.go
+++ b/provider/lib.go
@@ -494,6 +494,10 @@ func flattenRuleActions(actions []sigsci.Action, customResponseCode bool) []inte
 			// response code is set to 0 by sigsci api when action.type != "block"
 			// for types such as "allow" or "logRequest", response code is irrelevant and hence not provided in API response
 			actionMap["response_code"] = action.ResponseCode
+
+			if action.ResponseCode == 301 || action.ResponseCode == 302 {
+				actionMap["redirect_url"] = action.RedirectURL
+			}
 		}
 		actionsMap[i] = actionMap
 	}


### PR DESCRIPTION
It was reported that when using `redirect_url` changes were being presented when applying a plan, even though there were not any changes being made.

This was due to `redirect_url` not being reset during rule flattening within `flattenRuleActions`.

This commit fixes that and adds `redirect_url` to the `actionmap` within `flattenRuleActions`.