### PR TITLE
Serialize edge deployment backend updates via mutex

### DIFF
--- a/provider/lib.go
+++ b/provider/lib.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/signalsciences/go-sigsci"
@@ -24,6 +25,7 @@ func suppressRequestLoggingDefaultDiffs(k, old, new string, d *schema.ResourceDa
 type providerMetadata struct {
 	Corp   string
 	Client sigsci.Client
+	Mutex  *sync.Mutex
 }
 
 func flattenStringArray(entries []string) []interface{} {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/signalsciences/go-sigsci"
+	"sync"
 )
 
 // Provider is the Signalsciences terraform provider, returns a terraform.ResourceProvider
@@ -89,6 +90,8 @@ func Provider() terraform.ResourceProvider {
 	return provider
 }
 
+var ProviderMutex sync.Mutex
+
 func providerConfigure() schema.ConfigureFunc {
 	return func(d *schema.ResourceData) (interface{}, error) {
 		config := Config{
@@ -106,6 +109,7 @@ func providerConfigure() schema.ConfigureFunc {
 		metadata := providerMetadata{
 			Corp:   d.Get("corp").(string),
 			Client: client.(sigsci.Client),
+			Mutex:  &ProviderMutex,
 		}
 
 		validate := d.Get("validate").(bool)

--- a/provider/resource_edge_deployment_service_update_backend.go
+++ b/provider/resource_edge_deployment_service_update_backend.go
@@ -37,6 +37,9 @@ func updateEdgeDeploymentServiceBackend(d *schema.ResourceData, m interface{}) e
 
 	d.SetId(d.Get("fastly_sid").(string))
 
+	ProviderMutex.Lock()
+	defer ProviderMutex.Unlock()
+
 	return pm.Client.UpdateEdgeDeploymentBackends(pm.Corp, d.Get("site_short_name").(string), d.Get("fastly_sid").(string))
 
 }


### PR DESCRIPTION
Fixes #201 

When multiple calls to `edgeDeployment/<sid>/backends` occur simultaneously for different service IDs during a single Terraform apply, it's common for one to fail with the error message: `Error: failed to activate service.` This issue seems to stem from an API constraint.

This PR introduces a provider mutex that can be used to serialize access to this API call (and could also be used for others, if required). This avoids the need to set `-parallelism=1` globally, which we'd prefer not to do when running alongside the `fastly` provider, because it would unnecessarily limit the throughput of that provider as well.
