### PR TITLE
MINOR: site_rule: add support for browserChallenge

### DIFF
--- a/docs/resources/site_rule.md
+++ b/docs/resources/site_rule.md
@@ -245,10 +245,11 @@ Optional:
 
 Required:
 
-- `type` (String) (block, allow, excludeSignal, addSignal) (rateLimit rule valid values: logRequest, blockSignal)
+- `type` (String) (addSignal, allow, block, browserChallenge, excludeSignal) (rateLimit rule valid values: logRequest, blockSignal)
 
 Optional:
 
+- `allow_interactive` (Boolean) Allows toggling between a non-interactive and interactive browser challenge. Only valid with the 'browserChallenge' action type.
 - `redirect_url` (String) URL to redirect to when blocking response code is set to 301 or 302
 - `response_code` (Number) HTTP code agent for agent to respond with. range: 301, 302, or 400-599, defaults to '406' if not provided. Only valid with the 'block' action type.
 - `signal` (String) signal id to tag

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/hashicorp/terraform-plugin-docs v0.14.1
 	github.com/hashicorp/terraform-plugin-sdk v1.14.0
-	github.com/signalsciences/go-sigsci v0.1.19
+	github.com/signalsciences/go-sigsci v0.1.20
 	golang.org/x/lint v0.0.0-20190409202823-959b441ac422
 	honnef.co/go/tools v0.4.2
 )

--- a/go.sum
+++ b/go.sum
@@ -419,6 +419,7 @@ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc
 golang.org/x/tools v0.6.0 h1:BOw41kyTf3PuCW1pVQf8+Cyg8pMlkYB1oo9iJ6D/lKM=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=

--- a/go.sum
+++ b/go.sum
@@ -259,6 +259,8 @@ github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5g
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/signalsciences/go-sigsci v0.1.19 h1:PV826ftNXvVjV+VW2kQegCWcK+sQ5FUlJvPlifcOyNk=
 github.com/signalsciences/go-sigsci v0.1.19/go.mod h1:CXwoXk81ZwFdne6o8cnAYwxvke5kcLg7zE6Bl/e1KUo=
+github.com/signalsciences/go-sigsci v0.1.20 h1:lMirioZwNWhnizOqryzvr1dsvOpmOn2e4MK+XEzlXrA=
+github.com/signalsciences/go-sigsci v0.1.20/go.mod h1:CXwoXk81ZwFdne6o8cnAYwxvke5kcLg7zE6Bl/e1KUo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=

--- a/provider/lib.go
+++ b/provider/lib.go
@@ -427,11 +427,17 @@ func expandRuleActions(actionsResource *schema.Set) []sigsci.Action {
 			redirectURL = castElement["redirect_url"].(string)
 		}
 
+		var allowInteractive bool
+		if castElement["allow_interactive"] != nil {
+			allowInteractive = castElement["allow_interactive"].(bool)
+		}
+
 		a := sigsci.Action{
-			Type:         castElement["type"].(string),
-			Signal:       signal,
-			ResponseCode: responseCode,
-			RedirectURL:  redirectURL,
+			Type:             castElement["type"].(string),
+			Signal:           signal,
+			ResponseCode:     responseCode,
+			RedirectURL:      redirectURL,
+			AllowInteractive: allowInteractive,
 		}
 		actions = append(actions, a)
 	}
@@ -525,6 +531,10 @@ func flattenRuleActions(actions []sigsci.Action, customResponseCode bool) []inte
 
 			if action.ResponseCode == 301 || action.ResponseCode == 302 {
 				actionMap["redirect_url"] = action.RedirectURL
+			}
+
+			if action.AllowInteractive {
+				actionMap["allow_interactive"] = action.AllowInteractive
 			}
 		}
 		actionsMap[i] = actionMap

--- a/provider/resource_site_rule.go
+++ b/provider/resource_site_rule.go
@@ -63,7 +63,7 @@ func resourceSiteRule() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"type": {
 							Type:        schema.TypeString,
-							Description: "(block, allow, excludeSignal, addSignal) (rateLimit rule valid values: logRequest, blockSignal)",
+							Description: "(addSignal, allow, block, browserChallenge, excludeSignal) (rateLimit rule valid values: logRequest, blockSignal)",
 							Required:    true,
 						},
 						"signal": {
@@ -82,6 +82,11 @@ func resourceSiteRule() *schema.Resource {
 							Description:  "URL to redirect to when blocking response code is set to 301 or 302",
 							Optional:     true,
 							ValidateFunc: validateActionRedirectURL,
+						},
+						"allow_interactive": {
+							Type:        schema.TypeBool,
+							Description: "Allows toggling between a non-interactive and interactive browser challenge. Only valid with the 'browserChallenge' action type.",
+							Optional:    true,
 						},
 					},
 				},


### PR DESCRIPTION
This commit adds support for the `browserChallenge` action type within a Site Rule. Specifically, it documents that `browserChallenge` is available with action types. It also adds support for the `allowInteractive` boolean, which allows for toggling between non-interactive and interactive challenges.

This commit depends on signalsciences/go-sigsci#60