### PR TITLE
DOC: add verifyToken to site rules

### DIFF
--- a/docs/resources/site_rule.md
+++ b/docs/resources/site_rule.md
@@ -245,7 +245,7 @@ Optional:
 
 Required:
 
-- `type` (String) (addSignal, allow, block, browserChallenge, excludeSignal) (rateLimit rule valid values: logRequest, blockSignal)
+- `type` (String) (addSignal, allow, block, browserChallenge, excludeSignal, verifyToken) (rateLimit rule valid values: logRequest, blockSignal)
 
 Optional:
 

--- a/provider/resource_site_rule.go
+++ b/provider/resource_site_rule.go
@@ -63,7 +63,7 @@ func resourceSiteRule() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"type": {
 							Type:        schema.TypeString,
-							Description: "(addSignal, allow, block, browserChallenge, excludeSignal) (rateLimit rule valid values: logRequest, blockSignal)",
+							Description: "(addSignal, allow, block, browserChallenge, excludeSignal, verifyToken) (rateLimit rule valid values: logRequest, blockSignal)",
 							Required:    true,
 						},
 						"signal": {


### PR DESCRIPTION
This commit extends the documentation to make it clear that `verifyToken` is usable as an action within a site rule.