### PR TITLE
Update validateActionResponseCode

### DIFF
--- a/provider/lib.go
+++ b/provider/lib.go
@@ -609,7 +609,7 @@ func validateConditionField(val interface{}, key string) ([]string, []error) {
 func validateActionResponseCode(val interface{}, key string) ([]string, []error) {
 	// response code needs to be 301, 302, or 400-599
 	code := val.(int)
-	if (code >= 301 && code <= 302) || (code >= 400 && code <= 599) {
+	if (code == 0) || (code >= 301 && code <= 302) || (code >= 400 && code <= 599) {
 		return nil, nil
 	}
 	rangeError := fmt.Errorf("received action responseCode '%d'. should be in 301, 302, or 400-599", code)


### PR DESCRIPTION
Updating the function to allow for a response code of zero. Response code zero is used when the site default response code is utilized.