### PR TITLE
DOC: rules: add browserChallenge to rate limit rule

### DIFF
--- a/docs/resources/site_rule.md
+++ b/docs/resources/site_rule.md
@@ -259,7 +259,7 @@ Optional:
 
 Required:
 
-- `type` (String) (addSignal, allow, block, browserChallenge, excludeSignal, verifyToken) (rateLimit rule valid values: logRequest, blockSignal)
+- `type` (String) (addSignal, allow, block, browserChallenge, excludeSignal, verifyToken) (rateLimit rule valid values: logRequest, blockSignal, browserChallenge, verifyToken)
 
 Optional:
 

--- a/provider/resource_site_rule.go
+++ b/provider/resource_site_rule.go
@@ -63,7 +63,7 @@ func resourceSiteRule() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"type": {
 							Type:        schema.TypeString,
-							Description: "(addSignal, allow, block, browserChallenge, excludeSignal, verifyToken) (rateLimit rule valid values: logRequest, blockSignal)",
+							Description: "(addSignal, allow, block, browserChallenge, excludeSignal, verifyToken) (rateLimit rule valid values: logRequest, blockSignal, browserChallenge, verifyToken)",
 							Required:    true,
 						},
 						"signal": {


### PR DESCRIPTION
This commit updates the documentation for rate limit rules to specify that browserChallenge and verifyToken are now usable.