### PR TITLE
BUG/MINOR: release: remove deprecated --rm-dist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           # GitHub sets this automatically


### PR DESCRIPTION
goreleaser has deprecated (and removed) --rm-dist. They are suggesting migration to `--clean`.

https://goreleaser.com/deprecations/#scoop