### PR TITLE
MINOR: edge: add new custom_client_ip option

### DIFF
--- a/docs/resources/edge_deployment_service.md
+++ b/docs/resources/edge_deployment_service.md
@@ -32,6 +32,7 @@ resource "sigsci_edge_deployment_service" "my-service" {
 ### Optional
 
 - `activate_version` (Boolean) activate Fastly service version after clone. Possible values are true or false. Defaults to true.
+- `custom_client_ip` (Boolean) enable to prevent Fastly-Client-IP from being overwritten by the NGWAF. Intended for advanced use cases. Defaults to false.
 - `percent_enabled` (Number) percentage of traffic to send to NGWAF@Edge. Possible values are integers values 0 to 100. Defaults to 0.
 
 ### Read-Only

--- a/docs/resources/site_agent_alert.md
+++ b/docs/resources/site_agent_alert.md
@@ -18,10 +18,12 @@ description: |-
 ### Required
 
 - `action` (String) Action for agent alert.
-- `interval` (Number) Integer value for interval. Must be 5, 10 or 60.
+- `field_name` (String) Field_name for agent alert.
+- `interval` (Number) Integer value for interval. Must be 5, 10, or 60.
+- `operator` (String) Operator for agent alert.
 - `site_short_name` (String) Site short name
 - `tag_name` (String) The name of the tag whose occurrences the alert is watching. Must match an existing tag
-- `threshold` (Number) The number of occurrences of the tag in the interval needed to trigger the alert. Min 0, Max 10000
+- `threshold` (Number) The number of occurrences of the tag in the interval needed to trigger the alert. Min 0, Max 3600000
 
 ### Optional
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/hashicorp/terraform-plugin-docs v0.14.1
 	github.com/hashicorp/terraform-plugin-sdk v1.14.0
-	github.com/signalsciences/go-sigsci v0.1.22
+	github.com/signalsciences/go-sigsci v0.1.23
 	golang.org/x/lint v0.0.0-20190409202823-959b441ac422
 	honnef.co/go/tools v0.4.2
 )

--- a/go.sum
+++ b/go.sum
@@ -263,6 +263,8 @@ github.com/signalsciences/go-sigsci v0.1.21 h1:5lkqv66jlPxqe7BHv46eEefttGo/6nRqL
 github.com/signalsciences/go-sigsci v0.1.21/go.mod h1:CXwoXk81ZwFdne6o8cnAYwxvke5kcLg7zE6Bl/e1KUo=
 github.com/signalsciences/go-sigsci v0.1.22 h1:WDDYLS5sVbUcPgDAOrxjDfIWdfuBjISOtHvwDIR1U7M=
 github.com/signalsciences/go-sigsci v0.1.22/go.mod h1:CXwoXk81ZwFdne6o8cnAYwxvke5kcLg7zE6Bl/e1KUo=
+github.com/signalsciences/go-sigsci v0.1.23 h1:NrqxMi5JpNfpIUobbhnG/KDmNqM5h4/D/DVIqbyhN3k=
+github.com/signalsciences/go-sigsci v0.1.23/go.mod h1:CXwoXk81ZwFdne6o8cnAYwxvke5kcLg7zE6Bl/e1KUo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=

--- a/provider/resource_edge_deployment_service.go
+++ b/provider/resource_edge_deployment_service.go
@@ -31,7 +31,12 @@ func resourceEdgeDeploymentService() *schema.Resource {
 				Optional:    true,
 				Default:     true,
 			},
-
+			"custom_client_ip": {
+				Type:        schema.TypeBool,
+				Description: "enable to prevent Fastly-Client-IP from being overwritten by the NGWAF. Intended for advanced use cases. Defaults to false.",
+				Optional:    true,
+				Default:     false,
+			},
 			"percent_enabled": {
 				Type:        schema.TypeInt,
 				Description: "percentage of traffic to send to NGWAF@Edge. Possible values are integers values 0 to 100. Defaults to 0.",
@@ -46,8 +51,10 @@ func createOrUpdateEdgeDeploymentService(d *schema.ResourceData, m interface{}) 
 	pm := m.(providerMetadata)
 
 	activateVersion := d.Get("activate_version").(bool)
+	custom_client_ip := d.Get("custom_client_ip").(bool)
 	err := pm.Client.CreateOrUpdateEdgeDeploymentService(pm.Corp, d.Get("site_short_name").(string), d.Get("fastly_sid").(string), sigsci.CreateOrUpdateEdgeDeploymentServiceBody{
 		ActivateVersion: &activateVersion,
+		CustomClientIP:  &custom_client_ip,
 		PercentEnabled:  d.Get("percent_enabled").(int),
 	})
 


### PR DESCRIPTION
This commit adds the new option `custom_client_ip` to the Edge deployment resource. This option prevents the Fastly-Client-IP header from being overwritten by the NGWAF. It is intended for advanced use cases.