### PR TITLE
MINOR: integrations: add support for microsoftTeamsWorkflow

### DIFF
--- a/docs/resources/corp_integration.md
+++ b/docs/resources/corp_integration.md
@@ -27,7 +27,7 @@ resource "sigsci_corp_integration" "test_corp_integration" {
 
 ### Required
 
-- `type` (String) One of (mailingList, slack, microsoftTeams)
+- `type` (String) One of (mailingList, slack, microsoftTeams, microsoftTeamsWorkflow)
 - `url` (String) Integration URL
 
 ### Optional

--- a/docs/resources/site_integration.md
+++ b/docs/resources/site_integration.md
@@ -29,7 +29,7 @@ resource "sigsci_site_integration" "test_integration" {
 ### Required
 
 - `site_short_name` (String) Site short name
-- `type` (String) One of (mailingList, slack, datadog, generic, pagerduty, microsoftTeams, jira, opsgenie, victorops, pivotaltracker)
+- `type` (String) One of (mailingList, slack, datadog, generic, pagerduty, microsoftTeams, microsoftTeamsWorkflow, jira, opsgenie, victorops, pivotaltracker)
 - `url` (String) Integration URL
 
 ### Optional

--- a/provider/resource_corp_integration.go
+++ b/provider/resource_corp_integration.go
@@ -20,11 +20,11 @@ func resourceCorpIntegration() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"type": {
 				Type:        schema.TypeString,
-				Description: "One of (mailingList, slack, microsoftTeams)",
+				Description: "One of (mailingList, slack, microsoftTeams, microsoftTeamsWorkflow)",
 				Required:    true,
 				ForceNew:    true,
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-					if !existsInString(val.(string), "mailingList", "slack", "microsoftTeams") {
+					if !existsInString(val.(string), "mailingList", "slack", "microsoftTeams", "microsoftTeamsWorkflow") {
 						return nil, []error{fmt.Errorf(`received type %q is invalid. should be "mailingList", "slack", or "microsoftTeams"`, val.(string))}
 					}
 					return nil, nil

--- a/provider/resource_site_integration.go
+++ b/provider/resource_site_integration.go
@@ -23,7 +23,7 @@ func resourceSiteIntegration() *schema.Resource {
 			},
 			"type": {
 				Type:        schema.TypeString,
-				Description: "One of (mailingList, slack, datadog, generic, pagerduty, microsoftTeams, jira, opsgenie, victorops, pivotaltracker)",
+				Description: "One of (mailingList, slack, datadog, generic, pagerduty, microsoftTeams, microsoftTeamsWorkflow, jira, opsgenie, victorops, pivotaltracker)",
 				Required:    true,
 				ForceNew:    true,
 			},


### PR DESCRIPTION
This commit adds support for "Microsoft Teams (Workflows)". The integration type can be invoked through `microsoftTeamsWorkflow`.