### PR TITLE
MINOR: bump go-sigsci to v0.1.30

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/hashicorp/terraform-plugin-docs v0.14.1
 	github.com/hashicorp/terraform-plugin-sdk v1.14.0
-	github.com/signalsciences/go-sigsci v0.1.29
+	github.com/signalsciences/go-sigsci v0.1.30
 	golang.org/x/lint v0.0.0-20190409202823-959b441ac422
 	honnef.co/go/tools v0.4.2
 )

--- a/go.sum
+++ b/go.sum
@@ -259,6 +259,8 @@ github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5g
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/signalsciences/go-sigsci v0.1.29 h1:Ust66+EjhFOreWza6lTtqN/+PdXk7ZGsZEoi3jt7n2k=
 github.com/signalsciences/go-sigsci v0.1.29/go.mod h1:CXwoXk81ZwFdne6o8cnAYwxvke5kcLg7zE6Bl/e1KUo=
+github.com/signalsciences/go-sigsci v0.1.30 h1:Xk6g7czCk/KSH0fOjarVtfI3LWgcNnZXlYiafjt2DFQ=
+github.com/signalsciences/go-sigsci v0.1.30/go.mod h1:CXwoXk81ZwFdne6o8cnAYwxvke5kcLg7zE6Bl/e1KUo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=


### PR DESCRIPTION
This commit bumps the version of go-sigsci to v0.1.30.

Specifically it brings in the following change:
* BUG/MEDIUM: api: exclude DELETE calls from content-type check signalsciences/go-sigsci#74