### PR TITLE
BUG/MEDIUM: edge: fix remapping of service to another workspace

### DIFF
--- a/provider/resource_edge_deployment_service.go
+++ b/provider/resource_edge_deployment_service.go
@@ -47,6 +47,27 @@ func resourceEdgeDeploymentService() *schema.Resource {
 	}
 }
 
+func createEdgeDeploymentService(d *schema.ResourceData, m interface{}) error {
+	pm := m.(providerMetadata)
+
+	activateVersion := d.Get("activate_version").(bool)
+	custom_client_ip := d.Get("custom_client_ip").(bool)
+	percent_enabled := d.Get("percent_enabled").(int)
+	err := pm.Client.CreateOrUpdateEdgeDeploymentService(pm.Corp, d.Get("site_short_name").(string), d.Get("fastly_sid").(string), sigsci.CreateOrUpdateEdgeDeploymentServiceBody{
+		ActivateVersion: &activateVersion,
+		CustomClientIP:  &custom_client_ip,
+		PercentEnabled:  &percent_enabled,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId(d.Get("fastly_sid").(string))
+
+	return nil
+}
+
 func updateEdgeDeploymentService(d *schema.ResourceData, m interface{}) error {
 	pm := m.(providerMetadata)
 	fastlySID := d.Get("fastly_sid").(string)
@@ -76,27 +97,6 @@ func updateEdgeDeploymentService(d *schema.ResourceData, m interface{}) error {
 	}
 
 	d.SetId(fastlySID)
-
-	return nil
-}
-
-func createEdgeDeploymentService(d *schema.ResourceData, m interface{}) error {
-	pm := m.(providerMetadata)
-
-	activateVersion := d.Get("activate_version").(bool)
-	custom_client_ip := d.Get("custom_client_ip").(bool)
-	percent_enabled := d.Get("percent_enabled").(int)
-	err := pm.Client.CreateOrUpdateEdgeDeploymentService(pm.Corp, d.Get("site_short_name").(string), d.Get("fastly_sid").(string), sigsci.CreateOrUpdateEdgeDeploymentServiceBody{
-		ActivateVersion: &activateVersion,
-		CustomClientIP:  &custom_client_ip,
-		PercentEnabled:  &percent_enabled,
-	})
-
-	if err != nil {
-		return err
-	}
-
-	d.SetId(d.Get("fastly_sid").(string))
 
 	return nil
 }


### PR DESCRIPTION
It was recently identified by @BrooksCunningham that updating the `site_short_name` on a `sigsci_edge_deployment_service` object resulted in an error (`failed to attach service`). Successive runs of `terraform apply` would result in a succes, however, ultimately it was not working as expected.

This update of the `site_short_name` is what is known and documented as a "re-map" [1]. As the documentation shows, it requires first detaching the old workspace from the service using a `DELETE` call and then attaching a new workspace with a `PUT` call.

Previously, both Create & Update were using the same function, which prohibited proper detachment.

This commit introduces a update specific function `updateEdgeDeploymentService` and renames the existing `createOrUpdateEdgeDeploymentService` function to be exclusively used with Create (`createEdgeDeploymentService`).

[1] https://docs.fastly.com/en/ngwaf/configuring-edge-waf-deployments-using-the-next-gen-waf-control-panel#re-mapping-a-fastly-cdn-service-to-a-new-site-workspace