### PR TITLE
Update resource_site_rule.go

### DIFF
--- a/docs/resources/site_rule.md
+++ b/docs/resources/site_rule.md
@@ -276,7 +276,7 @@ Required:
 
 - `client_identifiers` (Block Set, Min: 1) Client Identifiers (see [below for nested schema](#nestedblock--rate_limit--client_identifiers))
 - `duration` (Number) duration in seconds (300 < x < 3600)
-- `interval` (Number) interval in minutes (1, 5, 10)
+- `interval` (Number) interval in minutes (1, 10)
 - `threshold` (Number) threshold
 
 <a id="nestedblock--rate_limit--client_identifiers"></a>

--- a/provider/resource_site_rule.go
+++ b/provider/resource_site_rule.go
@@ -213,7 +213,7 @@ func resourceSiteRule() *schema.Resource {
 						},
 						"interval": {
 							Type:        schema.TypeInt,
-							Description: "interval in minutes (1, 5, 10)",
+							Description: "interval in minutes (1, 10)",
 							Required:    true,
 						},
 						"duration": {


### PR DESCRIPTION
The service shows that it is possible to use 1, 5 or 10 minutes. But the code and the website show that the interval can only be 1 or 10 minutes.

This the error from the .tf. version = 3.7.0

│ Error: received unexpected content-type (text/plain; charset=utf-8) response: │ {"message":"Validation failed - interval must be 1 or 10"}