### PR TITLE
BUGFIX: signal_tag: drop client-side 3-25 char length validator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,6 @@ jobs:
       run: go build ./...
 
     - name: Staticcheck
-      uses: dominikh/staticcheck-action@v1.4.0
+      uses: dominikh/staticcheck-action@v1.4.1
       with:
         version: "latest"

--- a/docs/resources/corp_signal_tag.md
+++ b/docs/resources/corp_signal_tag.md
@@ -24,7 +24,7 @@ resource "sigsci_corp_signal_tag" "test" {
 
 ### Required
 
-- `short_name` (String) The display name of the signal tag. Must be 3-25 char.
+- `short_name` (String) The display name of the signal tag.
 
 ### Optional
 

--- a/docs/resources/site_signal_tag.md
+++ b/docs/resources/site_signal_tag.md
@@ -25,7 +25,7 @@ resource "sigsci_site_signal_tag" "test" {
 
 ### Required
 
-- `name` (String) The display name of the signal tag. Must be 3-25 char.
+- `name` (String) The display name of the signal tag.
 - `site_short_name` (String) Site short name
 
 ### Optional

--- a/provider/resource_corp_signal_tag.go
+++ b/provider/resource_corp_signal_tag.go
@@ -20,15 +20,9 @@ func resourceCorpSignalTag() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"short_name": {
 				Type:        schema.TypeString,
-				Description: "The display name of the signal tag. Must be 3-25 char.",
+				Description: "The display name of the signal tag.",
 				Required:    true,
 				ForceNew:    true,
-				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-					if !validStringLength(val.(string), 3, 25) {
-						return nil, []error{fmt.Errorf(`received short_name "%q" is invalid. should be min len 3, max len 25`, val.(string))}
-					}
-					return nil, nil
-				},
 			},
 			"description": {
 				Type:        schema.TypeString,

--- a/provider/resource_site_signal_tag.go
+++ b/provider/resource_site_signal_tag.go
@@ -24,15 +24,9 @@ func resourceSiteSignalTag() *schema.Resource {
 			},
 			"name": {
 				Type:        schema.TypeString,
-				Description: "The display name of the signal tag. Must be 3-25 char.",
+				Description: "The display name of the signal tag.",
 				Required:    true,
 				ForceNew:    true, // TODO Hopefully this can be changed in the api later
-				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-					if !validStringLength(val.(string), 3, 25) {
-						return nil, []error{fmt.Errorf(`received name %q is invalid. should be min len 3, max len 25`, val.(string))}
-					}
-					return nil, nil
-				},
 			},
 			"description": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
The SigSci API and Console accept signal tag short names longer than 25 characters, but the client-side ValidateFunc on sigsci_site_signal_tag.name and sigsci_corp_signal_tag.short_name rejects them. The result is that any tag created via the Console with a 26+ char shortName cannot be imported and managed in Terraform — `terraform plan` fails with `received name "..." is invalid. should be min len 3, max len 25` on a tag the backend already considers valid.

Remove the validator on both resources and let the API enforce length. The description string is also updated to drop the stale "Must be 3-25 char." claim.

Repro: create a site signal tag with a 26+ char name via the SigSci Console, `terraform import` it into a sigsci_site_signal_tag, then `terraform plan`.