### PR TITLE
MINOR: update signal length to 128 characters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,6 @@ jobs:
       run: go build ./...
 
     - name: Staticcheck
-      uses: dominikh/staticcheck-action@v1.4.0
+      uses: dominikh/staticcheck-action@v1.4.1
       with:
         version: "latest"

--- a/provider/resource_corp_signal_tag.go
+++ b/provider/resource_corp_signal_tag.go
@@ -20,12 +20,12 @@ func resourceCorpSignalTag() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"short_name": {
 				Type:        schema.TypeString,
-				Description: "The display name of the signal tag. Must be 3-25 char.",
+				Description: "The display name of the signal tag. Must be 3-128 char.",
 				Required:    true,
 				ForceNew:    true,
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-					if !validStringLength(val.(string), 3, 25) {
-						return nil, []error{fmt.Errorf(`received short_name "%q" is invalid. should be min len 3, max len 25`, val.(string))}
+					if !validStringLength(val.(string), 3, 128) {
+						return nil, []error{fmt.Errorf(`received short_name "%q" is invalid. should be min len 3, max len 128`, val.(string))}
 					}
 					return nil, nil
 				},

--- a/provider/resource_site_signal_tag.go
+++ b/provider/resource_site_signal_tag.go
@@ -24,12 +24,12 @@ func resourceSiteSignalTag() *schema.Resource {
 			},
 			"name": {
 				Type:        schema.TypeString,
-				Description: "The display name of the signal tag. Must be 3-25 char.",
+				Description: "The display name of the signal tag. Must be 3-128 char.",
 				Required:    true,
 				ForceNew:    true, // TODO Hopefully this can be changed in the api later
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-					if !validStringLength(val.(string), 3, 25) {
-						return nil, []error{fmt.Errorf(`received name %q is invalid. should be min len 3, max len 25`, val.(string))}
+					if !validStringLength(val.(string), 3, 128) {
+						return nil, []error{fmt.Errorf(`received name %q is invalid. should be min len 3, max len 128`, val.(string))}
 					}
 					return nil, nil
 				},


### PR DESCRIPTION
The signal length limit was recently increased from 25 characters to 128. This commit reflects that change.